### PR TITLE
Add support for tool collection

### DIFF
--- a/client-server-script
+++ b/client-server-script
@@ -201,10 +201,7 @@ fi
 
 do_roadblock client-server-script-start 300 ||
     exit_error "roablock for client-server-script-start timed out"
-do_roadblock client-server-start-tools 300 ||
-    exit_error "roablock for client-server-start-tools timed out"
 
-# start tools here
 echo -e "\nClients/servers starting tools"
 
 pushd "$cs_dir" >/dev/null ||
@@ -244,10 +241,21 @@ while read line; do
 done < "$cs_files_list"
 
 # Finally, get the commands file
-scp_from_controller "$ssh_id_file" "$rickshaw_run_dir/client-server-commands/$cs_id" "$cs_id.cmds"
-if [ ! -e ""$cs_id.cmds ]; then
-    exit_error "Could not find $cs_id.cmds"
-fi
+for file_type in bench tool-start tool-stop; do
+    scp_from_controller "$ssh_id_file" "$rickshaw_run_dir/client-server-$file_type-commands/$cs_id" "$cs_id-$file_type.cmds"
+    if [ ! -e ""$cs_id-$file_type.cmds ]; then
+        exit_error "Could not find $cs_id-$file_type.cmds"
+    fi
+done
+
+mkdir -p tool-data
+pushd tool-data >/dev/null
+do_roadblock client-server-start-tools 300 ||
+    exit_error "roablock for client-server-start-tools timed out"
+while read tool_start_cmd; do
+    $tool_start_cmd
+done < "$endpoint_run_dir/$cs_id/$cs_id-tool-start.cmds"
+popd >/dev/null
 
 # Run the actual tests by reading the commands file
 while read line; do
@@ -260,7 +268,8 @@ while read line; do
     mkdir -p $iter_samp_dir ||
         exit_error "Could not mkdir iteration-$iter/sample-$samp"
     find . -mindepth 1 -maxdepth 1 -type f | grep -v -- "$cs_id-stderrout.txt" | \
-        grep -v -- "$cs_id.cmds" | grep -v -- "$cs_files_list" | \
+        grep -v -- "$cs_id-bench.cmds" | grep -v -- "$cs_id-tool.cmds" | \
+        grep -v -- "$cs_files_list" | \
         cpio -pdum iteration-$iter/sample-$samp/ ||
         exit_error "Could not copy files from $cs_dir to $iter_samp_dir with find & cpio"
     pushd $iter_samp_dir || exit_error "Could not chdir to $iter_samp_dir"
@@ -308,12 +317,17 @@ while read line; do
     done
     popd >/dev/null  # from $iter_sampl_dir back to $cs_dir
     echo PWD: `/bin/pwd`
-done < "$endpoint_run_dir/$cs_id/$cs_id.cmds"
+done < "$endpoint_run_dir/$cs_id/$cs_id-bench.cmds"
 
 do_roadblock client-server-stop-tools 300 ||
     exit_error "roadblock for client-server-stop-tools timed out"
 echo -e "\nClients/servers stopping tools"
-# stop-tools command here
+pushd tool-data >/dev/null
+while read tool_stop_cmd; do
+    $tool_stop_cmd
+done < "$endpoint_run_dir/$cs_id/$cs_id-tool-stop.cmds"
+popd >/dev/null
+
 do_roadblock client-server-send-data 300 ||
     exit_error "roadblock for client-server-send-data timed out"
 echo -e "\nClients/servers copying data back to endpoint"

--- a/endpoints/local/local
+++ b/endpoints/local/local
@@ -233,6 +233,9 @@ elif [ "$osruntime" == "chroot" ]; then
     if [ "$container_name" == "$endpoint_label" ]; then
         container_mount=`buildah mount "$container_name"`
         echo "container mount: $container_mount"
+        for fs in dev proc sys; do
+            mount --verbose --options bind /$fs $container_mount/$fs
+        done
         endpoint_run_dir=$container_mount/endpoint-run
         # for chroot osruntime we can also simply copy the ssh key
         /bin/cp -f "$rickshaw_run_dir/rickshaw_id.rsa" $endpoint_run_dir
@@ -325,6 +328,7 @@ echo roadblock $i exit code: $rb_rc
 if [ $rb_rc -gt 0 ]; then
     exit_error "Exiting: exit code $rb_rc from roadblock $roadblock_id:client-server-start-tools"
 fi
+# Process the first client's bench-commands to participate in the roadblocks
 while read line; do
     iter_samp=`echo $line | awk '{print $1}'`
     iter=`echo $iter_samp | awk -F- '{print $1}'`
@@ -344,7 +348,7 @@ while read line; do
             exit_error "Exiting: exit code 2 (timeout) from roadblock iteration $iter, sample $samp"
         fi
     done
-done < "$rickshaw_run_dir/client-server-commands/client-1"
+done < "$rickshaw_run_dir/client-server-bench-commands/client-1"
 echo "Out of test loop"
 for i in client-server-stop-tools client-server-send-data client-server-script-finish \
          endpoint-move-data endpoint-finish endpoint-really-finish; do
@@ -357,7 +361,10 @@ for i in client-server-stop-tools client-server-send-data client-server-script-f
     fi
 done
 
-if [ "$osruntime" == "chrooty" ]; then
+if [ "$osruntime" == "chroot" ]; then
+    for fs in dev proc sys; do
+         umount $container_mount/$fs
+    done
     echo "Removing mount $container_name for chroot osruntime"
     buildah unmount "$container_name"
     echo "Removing container $container_name for chroot runtime"

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -54,7 +54,9 @@ sub usage {
     print "--workshop-dir   Directory where workshop project exists\n";
     print "--roadblock-dir  Directory where workshop project exists\n";
     print "--bench-dir      Directory where benchmark helper project exists\n";
-    print "--bench-params   File whith benchmark parameters to use\n";
+    print "--bench-params  File with benchmark parameters to use\n";
+    print "--tools-dir     Directory where *all* tool subprojects exist (like \$CRUCIBLE_HOME/subprojects/tools)\n";
+    print "--tool-params   File with tool parameters to use\n";
     print "--num-samples    The number of sample exeuctions to run for each benchmark iteration\n";
     print "--test-order     's' = run all samples of an iteration first\n";
     print "                 'i' = run all iterations of a sample first\n\n";
@@ -189,8 +191,9 @@ while (scalar @ARGV > 0) {
     } elsif ($arg =~ /^help$/) {
         usage;
         exit 0;
-    } elsif ($arg =~ /^run-id$|^run-dir$|^workshop-dir$|^bench-dir$|^roadblock-dir$/ or
-             $arg =~ /^bench-params$|^test-order$|^tool-group$|^num-samples$|^name$/ or
+    } elsif ($arg =~ /^run-dir$|^workshop-dir$|^bench-dir$|^roadblock-dir$|^tools-dir$/ or
+             $arg =~ /^run-id$|^bench-params$|^tool-params$|^bench-params$/ or
+             $arg =~ /^test-order$|^tool-group$|^num-samples$|^name$/ or
              $arg =~ /^email$|^tags$|^desc$|^json-validator/) {
         debug_log(sprintf "argument: [%s]\n", $arg);
         $run{$arg} = $val;
@@ -244,6 +247,21 @@ for my $params (@param_sets) {
     $iter_id++;
 }
 
+exists $run{'tools-dir'} || die "[ERROR]You must use " . 
+                                "--tools-dir=/path/to/tools/base/subproject-dir " .
+                                "(\$CRUCIBLE_HOME/subprojects/tools)\n";
+# Load the tool config
+if (not exists $run{'tool-params'} ) {
+    $run{'tool-params'} = $rickshaw_dir . "/config/tools.json";
+}
+my @tools_params = @{ my $tools_params_ref = get_json_file($run{'tool-params'}) };
+my %tools_configs;
+# Load a tool configuration for every tool the user is asking for
+foreach my $tool_entry (@tools_params) {
+    my $json_ref = get_json_file($run{'tools-dir'} . "/" . $$tool_entry{'tool'} . "/rickshaw.json");
+    $tools_configs{$$json_ref{'tool'}} = $json_ref;
+}
+
 # Apply defaults
 foreach my $p (keys %defaults) {
     if (! exists $run{$p}) {
@@ -252,8 +270,9 @@ foreach my $p (keys %defaults) {
     }
 }
 
-# Ensure the bench-dir and run-dir have absolute paths
-for my $dirtype (qw(run-dir bench-dir)) {
+# Ensure the bench-dir, run-dir, and tools-dir have absolute paths
+# because they may be referenced by clients and servers later
+for my $dirtype (qw(run-dir bench-dir tools-dir)) {
     {
         my $dir = pushd($run{$dirtype});
         debug_log(sprintf "pushd to [%s]\n", $run{$dirtype});
@@ -365,7 +384,7 @@ if ($use_roadblock) {
                               " --roadblock-id=" . $run{'run-id'} .
                               " --roadblock-passwd=" . $redis_passwd;
     $workshop_roadblock_opt = " --requirements " . $run{'roadblock-dir'} .
-                              "/workshop.json";
+                              "/workshop.json ";
 } else {
     # If for some reason the user has opted to not use roadblock, then only allow
     # tests which use only one client and no server, which is the only possible
@@ -438,30 +457,46 @@ copy($rickshaw_dir . "/client-server-script", $base_endpoint_run_dir . "/client-
     || die "Could not copy client-server-script to " . $base_endpoint_run_dir .
            "/client-server-script";
 chmod 0755, $base_endpoint_run_dir . "/client-server-script";
-# Build the client and server benchmark-command files and put them in the base endpoint run dir
-my $cs_cmds_dir = $run{'run-dir'} . "/client-server-commands";
+
+# Build the client and server benchmark-command and tool-command files
+# and put them in the base endpoint run dir
+my $cs_cmds_dir = $run{'run-dir'} . "/client-server-bench-commands";
+my $cs_tool_start_cmds_dir = $run{'run-dir'} . "/client-server-tool-start-commands";
+my $cs_tool_stop_cmds_dir = $run{'run-dir'} . "/client-server-tool-stop-commands";
 -e $cs_cmds_dir || mkdir($cs_cmds_dir) ||
     die "[ERROR]Could not create directory for endpoint scripts: [" . $cs_cmds_dir . "]\n";
+-e $cs_tool_start_cmds_dir || mkdir($cs_tool_start_cmds_dir) ||
+    die "[ERROR]Could not create directory for endpoint scripts: [" . $cs_tool_start_cmds_dir . "]\n";
+-e $cs_tool_stop_cmds_dir || mkdir($cs_tool_stop_cmds_dir) ||
+    die "[ERROR]Could not create directory for endpoint scripts: [" . $cs_tool_stop_cmds_dir . "]\n";
 foreach my $cs_type (keys %clients_servers) {
     foreach my $cs_ref (@{ $clients_servers{$cs_type} }) {
         my $cs_id = $$cs_ref{'id'};
         my $cs_type_id = $cs_type . "-" . $cs_id;
         my $cmd_file = $cs_cmds_dir . "/" . $cs_type_id;
+        my $tool_start_cmd_file = $cs_tool_start_cmds_dir . "/" . $cs_type_id;
+        my $tool_stop_cmd_file = $cs_tool_stop_cmds_dir . "/" . $cs_type_id;
         open(FH, ">" . $cmd_file) || die "[ERROR]could not open cmd file for writing: ["
                                             . $cmd_file . "]\n";
         debug_log(sprintf "writing script file [%s]\n", $cmd_file);
+        open(TOOL_START_FH, ">" . $tool_start_cmd_file) || die "[ERROR]could not open cmd file for writing: ["
+                                            . $tool_start_cmd_file . "]\n";
+        debug_log(sprintf "writing script file [%s]\n", $tool_start_cmd_file);
+        open(TOOL_STOP_FH, ">" . $tool_stop_cmd_file) || die "[ERROR]could not open cmd file for writing: ["
+                                            . $tool_stop_cmd_file . "]\n";
+        debug_log(sprintf "writing script file [%s]\n", $tool_stop_cmd_file);
         foreach my $test_ref (@tests) {
             my $test_iter = $$test_ref{'iteration-id'};
             my $test_samp = $$test_ref{'sample-id'};
-            #my $param_id = $test_iter - 1;
             my $iter_array_idx = $test_iter - 1;
             my $rb_session = "start-test:" . $test_iter . "-" . $test_samp;
             if (exists $bench_config{$cs_type}{"bin"} and
             $bench_config{$cs_type}{"bin"} ne "") {
-                my $cmd = $bench_config{$cs_type}{"bin"} . " " . dump_params($run{'iterations'}[$iter_array_idx]{'params'}, $cs_id);
+                my $cmd = $bench_config{$cs_type}{"bin"} . " " .
+                          dump_params($run{'iterations'}[$iter_array_idx]{'params'}, $cs_id);
                 debug_log(sprintf "cmd: [%s]\n", $cmd);
                 # Apply a regex from the benchmark config file to the command
-                    # This is used to remove things like "--clients=" because the
+                # This is used to remove things like "--clients=" because the
                 # native benchmark does not understand this parameter
                 if ($bench_config{$cs_type} and $bench_config{$cs_type}{"param_regex"}) {
                     for my $r (@{ $bench_config{$cs_type}{"param_regex"} }) {
@@ -478,13 +513,30 @@ foreach my $cs_type (keys %clients_servers) {
         }
         close FH;
         chmod 0755, $cmd_file;
+        foreach my $tool_entry (@tools_params) {
+            my $tool_name = $$tool_entry{'tool'};
+            my $tool_start_cmd = $tools_configs{$tool_name}{'collector'}{'start'};
+            my $tool_stop_cmd = $tools_configs{$tool_name}{'collector'}{'stop'};
+            printf "tool_start: %s\n", $tool_start_cmd;
+            printf "tool_stop: %s\n", $tool_stop_cmd;
+            foreach my $tool_param (@{ $$tool_entry{'params'} }) {
+                $tool_start_cmd .= " --" . $$tool_param{'arg'} . " " . $$tool_param{'val'};
+                $tool_stop_cmd .= " --" . $$tool_param{'arg'} . " " . $$tool_param{'val'};
+            }
+            printf TOOL_START_FH "%s\n", $tool_start_cmd;
+            printf TOOL_STOP_FH "%s\n", $tool_stop_cmd;
+        }
+        close TOOL_START_FH;
+        close TOOL_STOP_FH;
+        chmod 0755, $tool_start_cmd_file;
+        chmod 0755, $tool_stop_cmd_file;
     }
 }
 
 # Build the client/server "from-controller" files list and put them in the base endpoint run dir.
 # These are files the client/server must copy from the controller before running any tests.
 # The "client-server-script" will first scp the list (client-files-list or server-files-list).
-# then it will read this list to know what other files to vopy over)
+# then it will read this list to know what other files to copy over)
 foreach my $cs_type (keys %clients_servers) {
     my $cs_file_list = $run{'run-dir'} . "/" . $cs_type . "-files-list";
     open(FH, ">" . $cs_file_list) || die "[ERROR]could not open " . $cs_file_list . " for writing";
@@ -495,6 +547,18 @@ foreach my $cs_type (keys %clients_servers) {
             $src_file =~ s/\%run-dir\%/$run{'run-dir'}\//g;
             my $dest_file = $$file_spec{'dest'};
             printf FH "src=%s\ndest=%s\n", $src_file, $dest_file;
+        }
+    }
+    foreach my $tool_entry (@tools_params) {
+        my $tool_name = $$tool_entry{'tool'};
+        if (exists $tools_configs{$tool_name}{'collector'}{'files-from-controller'}) {
+            for my $file_spec (@{ $tools_configs{$tool_name}{'collector'}{"files-from-controller"} } ) {
+                my $src_file = $$file_spec{'src'};
+                $src_file =~ s/\%tool-dir\%/$run{'tools-dir'}\/$$tool_entry{'tool'}\//g;
+                $src_file =~ s/\%run-dir\%/$run{'run-dir'}\//g;
+                my $dest_file = $$file_spec{'dest'};
+                printf FH "src=%s\ndest=%s\n", $src_file, $dest_file;
+            }
         }
     }
     close FH;
@@ -508,33 +572,37 @@ if ($use_workshop) {
     my $must_rebuild = 0;
     my $image_time;
     my $image_name = "workshop_" . $userenv . "_" . $run{'benchmark'};
-    #my $image_json = `buildah  images --json $image_name`;
     my $image_json = `buildah  images --json`;
-    printf "image_json:\n%s\n", $image_json;
     my $coder = JSON::XS->new;
     my $image_json_ref = $coder->decode($image_json);
+    print Dumper $image_json_ref;
     my $image_found = 0;
     for (my $i=0; $i< scalar @$image_json_ref ; $i++) {
-        my $name = $$image_json_ref[$i]{'names'}[0];
-        $name =~ s/.*\///;
-        $name =~ s/:.*//;
-        if ($name eq $image_name) {
-            $image_found = 1;
-            $image_id = $$image_json_ref[$i]{'id'};
-            $image_time = $$image_json_ref[$i]{'createdatraw'};
-            $image_time = `date -d $image_time +%s`;
-            my @files = ($run{'bench-dir'} . "/workshop.json",
-                         $run{'workshop-dir'} . "/userenvs/" . $userenv . ".json",
-                         $rickshaw_dir . "/client-server-script");
-            for my $file (@files) {
-                if ( file_newer_than($file, $image_time) > 0) {
-                    printf "%s is newer than the container image\n", $file;
-                    $must_rebuild = 1;
+        if (exists $$image_json_ref[$i]{'names'}[0]) {
+            my $name = $$image_json_ref[$i]{'names'}[0];
+            $name =~ s/.*\///;
+            $name =~ s/:.*//;
+            if ($name eq $image_name) {
+                $image_found = 1;
+                $image_id = $$image_json_ref[$i]{'id'};
+                $image_time = $$image_json_ref[$i]{'createdatraw'};
+                $image_time = `date -d $image_time +%s`;
+                my @files = ($run{'bench-dir'} . "/workshop.json",
+                            $run{'workshop-dir'} . "/userenvs/" . $userenv . ".json",
+                            $rickshaw_dir . "/client-server-script");
+                foreach my $tool_entry (@tools_params) {
+                    push(@files, $run{'tools-dir'} . "/" . $$tool_entry{'tool'} . "/workshop.json");
+                }
+                for my $file (@files) {
+                    if ( file_newer_than($file, $image_time) > 0) {
+                        printf "%s is newer than the container image\n", $file;
+                        $must_rebuild = 1;
+                    }
                 }
             }
         }
     }
-    if ($must_rebuild or $image_found == 0) {
+    if ($must_rebuild or ! $image_found) {
         printf "The container image must be rebuilt\n";
         # Build a container image for the clients/servers
         # Create a json which tells workshop to include these files:
@@ -599,6 +667,10 @@ if ($use_workshop) {
                         " --requirements " . $cs_req_file .
                         " --json-validator " . $run{'json-validator'} .
                         $workshop_roadblock_opt; 
+        foreach my $tool_entry (@tools_params) {
+            $workshop_cmd .= " --requirements " . $run{'tools-dir'} . "/" .
+                             $$tool_entry{'tool'} . "/workshop.json ";
+        }
         printf "workshop cmd: %s\n", $workshop_cmd;
         my @workshop_output = `$workshop_cmd`;
         print join("", @workshop_output);


### PR DESCRIPTION
-Tools are started before the forst test and stopped after the last test
-A tool params JSON must be provided by the user to know what tools to run
 -Later multiplex or something else may support generating this for the user
-By default all tools run on clients and servers, but in future development
 exceptions can be made, blacklisting certain tools from clients/servers
 only under certain endpoints, and whitelisting tools for other places
 under the control of an endpoint (like a worker node for k8s).
-Rickshaw will now add requirements from tools for building a container
 image
-Rickshaw will build tool start/stop command files which clients/servers
 will run.  Eventually when tool blacklists are supported these command
 files will have certain tools removed based on what endpoint they are
 running from and what the tool config JSON has specificed.
-There will be a separate update for tool subproject sysstat with config
 file, start, and stop scripts.