### PR TITLE
Remove capture of stderr/out from client-server-script

### DIFF
--- a/client-server-script
+++ b/client-server-script
@@ -175,10 +175,7 @@ if [ -z "$cs_id" ]; then
     exit_error "The clien/server ID (--cs-id) was not defined"
 fi
 cs_dir="$endpoint_run_dir/$cs_id"
-/bin/mkdir -p "$cs_dir" ||
-    exit_error "Could not mkdir $cs_dir"
-exec >$endpoint_run_dir/$cs_id/$cs_id-stderrout.txt
-exec 2>&1
+/bin/mkdir -p "$cs_dir" || exit_error "Could not mkdir $cs_dir"
 
 cs_type=`echo $cs_id | awk -F- '{print $1}'`
 if [ -z "$rickshaw_host" ]; then

--- a/endpoints/local/local
+++ b/endpoints/local/local
@@ -272,7 +272,7 @@ for i in ${clients[@]} ${servers[@]}; do
                 $cmd
             else
                 echo -e "About to run using nohup:\n$cmd\n"
-                nohup $cmd &
+                nohup $cmd 2>&1 >"$rickshaw_run_dir/$i-stderrout.txt" &
             fi
         else
             exit_error "[ERROR]could not find script $rickshaw_run_dir/client-server-script"
@@ -289,7 +289,7 @@ for i in ${clients[@]} ${servers[@]}; do
             $cmd
         else
             echo -e "About to run using nohup:\n$cmd\n"
-            nohup $cmd &
+            nohup $cmd 2>&1 >"$rickshaw_run_dir/$i-stderrout.txt" &
         fi
     elif [ "$osruntime" == "podman"]; then
         echo doing podman runtime


### PR DESCRIPTION
-capturing a script's own output becomes tricky because often one needs
 to process script params (like a directory for writing) in order to
 know where to store the output log
-capturing the output to a file can make debugging more difficult especially
 if the client-server-script does before copying the output back to the
 controller
-each endpoint is not responsible for making sure each client-server-script
 execution's output iis copied to the $rickshaw_run_dir.  This commit handles
 this for 'local' endpoint