### PR TITLE
Endpoint updates

### DIFF
--- a/endpoints/k8s/k8s
+++ b/endpoints/k8s/k8s
@@ -284,8 +284,8 @@ function get_pod_logs() {
     while [ ! -z "$1" ]; do
         local name="$1"; shift
         echo "Getting logs from pod $name"
-        this_log="`echo $name | sed -e s/^$pod_prefix-//`.txt"
-        ssh $k8s_user@$k8s_host kubectl logs $name >/$client_server_logs_dir/$this_log
+        pod_name="rickshaw-$name"
+        ssh $k8s_user@$k8s_host kubectl logs $pod_name >/$client_server_logs_dir/$name
     done
 }
 
@@ -333,7 +333,7 @@ function get_k8s_config() {
             workers="$workers $name"
         fi
     done
-    masters=`ssh $k8s_user@$k8s_host kubectl get nodes | grep " master " | grep " Ready " | awk '{print $1}'`
+    masters=`ssh $k8s_user@$k8s_host kubectl get nodes | grep " master " | grep " Ready " | grep -v "SchedulingDisabled" | awk '{print $1}'`
     echo "$workers" >"$endpoint_run_dir/worker-nodes.txt"
     echo "$masters" >"$endpoint_run_dir/master-nodes.txt"
 }

--- a/endpoints/localhost/localhost
+++ b/endpoints/localhost/localhost
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
 
 # This script implements the 'local' endpoint for rickshaw.  It runs 1 or more
@@ -36,7 +36,7 @@ else
 fi
 
 endpoint_name="local"
-osruntime="builtin" # to be changed to "chroot" when implemented
+osruntime="chroot"
 
 function cleanup_osruntime() {
     if [ "$osruntime" == "chroot" ]; then
@@ -150,10 +150,10 @@ function launch_osruntime() {
             cmd="chroot $container_mount $base_cmd"
             if [ -z "$cs_rb_opts" ]; then
                 # Only when not using roadblock run the client in the foreground
-                $cmd 2>&1 | tee "$this_cs_log_file"
+                $cmd | tee "$this_cs_log_file"
             else
                 echo -e "About to run using nohup:\n$cmd\n"
-                nohup $cmd 2>&1 >"$this_cs_log_file" &
+                nohup $cmd >"$this_cs_log_file" &
             fi
         elif [ "$osruntime" == "podman"]; then
             echo doing podman runtime


### PR DESCRIPTION
-fix client-server log collection in k8s
-switch to chroot for default osruntime in localhost
-don't attept to capture stdout in running client-server-script
 -it does not work with nohup, and it's redirected to stdout
  anyway now.