### PR TITLE
This eliminates the need to include client-server-script in the conta…

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,0 +1,144 @@
+#!/bin/bash
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+#
+# The following is the minimum amount of code to copy over the client-server-script and no more.
+exec 2>&1
+
+# Some container images need this
+test -e /etc/profile && . /etc/profile
+
+# "/usr/local/bin" is not always in the $PATH but it needs to be
+PATH="/usr/local/bin:$PATH"
+
+function exit_error() {
+    local message=$1; shift
+    local code=$1; shift
+    echo -e "[ERROR]$message\n"
+    echo "Exiting"
+    if [ -z "$code" ]; then
+        exit 1
+    else
+        exit $code
+    fi
+}
+export -f exit_error
+
+function scp_from_controller() {
+    local ssh_id_file=$1; shift
+    local src=$1; shift
+    local dest=$1; shift
+    if [ -z "$ssh_id_file" ]; then
+        exit_error "scp_from_controller(): ssh_id_file not defined"
+    fi
+    if [ -z "$src" ]; then
+        exit_error "scp_from_controller(): src not defined"
+    fi
+    if [ -z "$dest" ]; then
+        exit_error "scp_from_controller(): dest not defined"
+    fi
+    local scp_attempts=1
+    local scp_rc=1
+    local max_attempts=10
+    scp_cmd="scp -o StrictHostKeyChecking=no"
+    scp_cmd+=" -o BatchMode=yes"
+    scp_cmd+=" -v"
+    scp_cmd+=" -o ConnectionAttempts=10"
+    scp_cmd+=" -i $ssh_id_file"
+    scp_cmd+=" -r $rickshaw_host:$src $dest"
+    while [ $scp_rc -gt 0 -a $scp_attempts -lt $max_attempts ]; do
+        echo "Trying to scp $rickshaw_host:$src $dest"
+        scp_output=`$scp_cmd 2>&1`
+        scp_rc=$?
+        if [ $scp_rc -gt 0 ]; then
+            echo "scp failed, trying again"
+            echo "scp exit code: $scp_rc"
+            echo "scp command: $scp_cmd"
+            echo "scp output:"
+            echo "$scp_output"
+            sleep $scp_attempts
+        fi
+        let scp_attempts=$scp_attempts+1
+    done
+    if [ $scp_attempts -ge $max_attempts ]; then
+        exit_error "Could not copy $src from $rickshaw_host"
+    fi
+}
+export -f scp_from_controller
+
+echo "bootstrap env:"
+env
+echo "bootstrap params:"
+echo "$@"
+echo
+longopts="rickshaw-host:,base-run-dir:,endpoint-run-dir:,cs-label:,roadblock-server:"
+longopts="${longopts},roadblock-passwd:,roadblock-id:"
+opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
+if [ $? -ne 0 ]; then
+    exit_error "\nUnrecognized option specified: $@\n\n"
+fi
+eval set -- "$opts";
+while true; do
+    case "$1" in
+        --rickshaw-host)
+            shift;
+            export rickshaw_host="$1"
+            shift;
+            ;;
+        --base-run-dir)
+            shift;
+            export base_run_dir=$1
+            shift;
+            ;;
+        --cs-label)
+            shift;
+            export cs_label="$1"
+            shift;
+            ;;
+        --endpoint-run-dir)
+            shift;
+            export endpoint_run_dir="$1"
+            shift;
+            ;;
+        --roadblock-server)
+            shift;
+            export roadblock_server="$1"
+            shift;
+            ;;
+        --roadblock-passwd)
+            shift;
+            export roadblock_passwd="$1"
+            shift;
+            ;;
+        --roadblock-id)
+            shift;
+            export roadblock_id="$1"
+            shift;
+            ;;
+        --)
+            shift;
+            break;
+           ;;
+        *)
+            exit_error "Unexpected argument [$1]"
+            shift;
+            break;
+            ;;
+    esac
+done
+export ssh_id_file="/tmp/rickshaw_id.rsa"
+if [ ! -z "$ssh_id" ]; then
+   echo -e "$ssh_id" > $ssh_id_file
+   chmod 600 $ssh_id_file
+fi
+if [ ! -e $ssh_id_file ]; then
+    exit_error "ssh key $ssh_id_file was not found"
+fi
+export config_dir="$base_run_dir/config"
+export client_server_config_dir="$config_dir/client-server"
+scp_from_controller "$ssh_id_file" "$client_server_config_dir/client-server-script" /usr/local/bin/
+if [ -e /usr/local/bin/client-server-script ]; then
+    /usr/local/bin/client-server-script
+else
+    exit_error "Could not find client-server-script"
+fi

--- a/client-server-script
+++ b/client-server-script
@@ -103,47 +103,6 @@ function do_roadblock() {
     fi
 }
 
-function scp_from_controller() {
-    local ssh_id_file=$1; shift
-    local src=$1; shift
-    local dest=$1; shift
-    if [ -z "$ssh_id_file" ]; then
-        exit_error "scp_from_controller(): ssh_id_file not defined"
-    fi
-    if [ -z "$src" ]; then
-        exit_error "scp_from_controller(): src not defined"
-    fi
-    if [ -z "$dest" ]; then
-        exit_error "scp_from_controller(): dest not defined"
-    fi
-    local scp_attempts=1
-    local scp_rc=1
-    local max_attempts=10
-    scp_cmd="scp -o StrictHostKeyChecking=no"
-    scp_cmd+=" -o BatchMode=yes"
-    scp_cmd+=" -v"
-    scp_cmd+=" -o ConnectionAttempts=10"
-    scp_cmd+=" -i $ssh_id_file"
-    scp_cmd+=" -r $rickshaw_host:$src $dest"
-    while [ $scp_rc -gt 0 -a $scp_attempts -lt $max_attempts ]; do
-        echo "Trying to scp $rickshaw_host:$src $dest"
-        scp_output=`$scp_cmd 2>&1`
-        scp_rc=$?
-        if [ $scp_rc -gt 0 ]; then
-            echo "scp failed, trying again"
-            echo "scp exit code: $scp_rc"
-            echo "scp command: $scp_cmd"
-            echo "scp output:"
-            echo "$scp_output"
-            sleep $scp_attempts
-        fi
-        let scp_attempts=$scp_attempts+1
-    done
-    if [ $scp_attempts -ge $max_attempts ]; then
-        exit_error "Could not copy $src from $rickshaw_host"
-    fi
-}
-
 function archive_to_controller() {
     local ssh_id_file=$1; shift
     local src=$1; shift # a directory to archive from
@@ -316,15 +275,6 @@ if [ "$cs_type" == "client" -o "$cs_type" == "server" ]; then
 else
     label=collector-script-start
     do_roadblock $label "endpoint" $client_server_script_timeout
-fi
-
-ssh_id_file="/tmp/rickshaw_id.rsa"
-if [ ! -z "$ssh_id" ]; then
-   echo -e "$ssh_id" > $ssh_id_file
-   chmod 600 $ssh_id_file
-fi
-if [ ! -e $ssh_id_file ]; then
-    exit_error "ssh key $ssh_id_file was not found"
 fi
 
 # Get files required to run benchmark and tools

--- a/endpoints/base
+++ b/endpoints/base
@@ -145,6 +145,7 @@ function init_common_dirs() {
         run_dir="$base_run_dir/run"
         client_server_logs_dir="$run_dir/client-server/logs"
         endpoint_run_dir="$run_dir/endpoint/$endpoint_label"
+        bootstrap_script="/usr/local/bin/bootstrap"
         client_server_run_script="/usr/local/bin/client-server-script"
         roadblock_msgs_dir="$endpoint_run_dir/roadblock-msgs"
         mkdir -p "$endpoint_run_dir"

--- a/endpoints/k8s/k8s
+++ b/endpoints/k8s/k8s
@@ -55,6 +55,7 @@ pod_prefix="rickshaw"
 userenv="rhubi8"
 hostNetwork="0"
 securityContext=""
+resources=""
 declare -A nodeSelector
 
 function endpoint_k8s_test_stop() {

--- a/endpoints/localhost/localhost
+++ b/endpoints/localhost/localhost
@@ -89,9 +89,9 @@ function localhost_req_check() {
 function launch_osruntime() {
     echo osruntime: $osruntime
     if [ "$osruntime" == "builtin" ]; then
-        # Only the container images already have the client-server-script,
+        # Only the container images already have the bootstrap,
         # so we must copy ourselves
-        /bin/cp $client_server_config_dir/client-server-script $client_server_run_script
+        /bin/cp $client_server_config_dir/bootstrap $bootstrap_script
         # All osruntimes need an ssh-key, but for osruntime "builtin" it can simply be copied here
         /bin/cp -f "$config_dir/rickshaw_id.rsa" /tmp/rickshaw_id.rsa
     elif [ "$osruntime" == "chroot" ]; then
@@ -119,12 +119,12 @@ function launch_osruntime() {
     # For each client and server launch the actual script which will run it.
     for this_cs_label in ${clients[@]} ${servers[@]}; do
         this_cs_log_file="$client_server_logs_dir/$this_cs_label.txt"
-        base_cmd="$client_server_run_script --rickshaw-host=localhost"
+        base_cmd="$bootstrap_script --rickshaw-host=localhost"
         base_cmd="$base_cmd --endpoint-run-dir=$endpoint_run_dir --cs-label=$this_cs_label $cs_rb_opts"
         base_cmd="$base_cmd --base-run-dir=$base_run_dir"
         if [ "$osruntime" == "builtin" ]; then
             cmd="$base_cmd"
-            if [ -e "$client_server_run_script" ]; then
+            if [ -e "$bootstrap_script" ]; then
                 if [ -z "$cs_rb_opts" ]; then
                     # Only when not using roadblock run the client in the foreground
                     echo -e "About to run in foreground:\n$cmd\n"
@@ -134,7 +134,7 @@ function launch_osruntime() {
                     nohup $cmd 2>&1 >"$this_cs_log_file" &
                 fi
             else
-                exit_error "[ERROR]could not find script $client_server_run_script"
+                exit_error "[ERROR]could not find script $bootstrap_script"
             fi
         elif [ "$osruntime" == "chroot" ]; then
             echo "using chroot"

--- a/endpoints/remotehost/remotehost
+++ b/endpoints/remotehost/remotehost
@@ -215,7 +215,7 @@ function launch_osruntime() {
     do_ssh $user@$host /bin/mkdir -p $remote_logs_dir
     for this_cs_label in ${clients[@]} ${servers[@]}; do
         this_cs_log_file="$this_cs_label.txt"
-        base_cmd="$client_server_run_script --rickshaw-host=$hostname"
+        base_cmd="/usr/local/bin/bootstrap --rickshaw-host=$hostname"
         base_cmd+=" --endpoint-run-dir=$endpoint_run_dir --cs-label=$this_cs_label $cs_rb_opts"
         base_cmd+=" --base-run-dir=$base_run_dir"
         if [ "$osruntime" == "chroot" ]; then

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -322,7 +322,8 @@ sub build_container_image {
                             }
                         },
                         'config' => {
-                            'entrypoint' => [ "/bin/sh", "-c", "/usr/local/bin/client-server-script" ]
+                            #'entrypoint' => [ "/bin/sh", "-c", "/usr/local/bin/client-server-script" ]
+                            'entrypoint' => [ "/bin/sh", "-c", "/usr/local/bin/bootstrap" ]
                         }
                     );
         my $cs_req_file = $config_dir . "/cs-req.json";
@@ -335,17 +336,19 @@ sub build_container_image {
                         'userenvs' => [
                             {
                                 'name' => 'default',
-                                'requirements' => [ 'endpoint-run', 'jq_src' ]
+                                'requirements' => [ 'bootstrap', 'jq_src' ]
                             }
                         ],
                         'requirements' => [
                             {
-                                'name' => 'endpoint-run',
+                                #'name' => 'endpoint-run',
+                                'name' => 'bootstrap',
                                 'type' => 'files',
                                 'files_info' => {
                                     'files' => [
                                         {
-                                            'src' => $rickshaw_project_dir . "/client-server-script",
+                                            #'src' => $rickshaw_project_dir . "/client-server-script",
+                                            'src' => $rickshaw_project_dir . "/bootstrap",
                                             'dst' => '/usr/local/bin'
                                         }
                                     ]
@@ -393,7 +396,8 @@ sub build_container_image {
         my @files = ($run{'bench-dir'} . "/workshop.json",
                     $run{'workshop-dir'} . "/userenvs/" . $userenv . ".json",
                     $cs_req_file, $cs_conf_file,
-                    $rickshaw_project_dir . "/client-server-script");
+                    #$rickshaw_project_dir . "/client-server-script");
+                    $rickshaw_project_dir . "/bootstrap");  # replaces ^^^
         foreach my $tool_entry (@tools_params) {
             push(@files, $run{'tools-dir'} . "/" . $$tool_entry{'tool'} . "/workshop.json");
         }


### PR DESCRIPTION
…iner

-We tend to modify client-server-script often, since this is still in the early stages
 of development.  Having client-server-script scp'd over after the osruntime starts
 eliminates the need to rebuild the container because something in client-server-script
 has changed.
-A new, small and hopefully rarely modifed script called bootstrap is in cluded in the
 container image, and it's job is to copy over client-server-script and start it.