### PR TITLE
rickshaw-run: skip package updates when using workshop

### DIFF
--- a/rickshaw-run
+++ b/rickshaw-run
@@ -449,6 +449,7 @@ sub build_container_image {
             my $workshop_image_id;
             my $workshop_cmd = $run{'workshop-dir'} . "/workshop.pl" .
                             #" --label " . $run{'benchmark'} .
+                            " --skip-update=true " .
                             " --config " . $cs_conf_file .
                             " --label " . $image_md5 .
                             " --userenv " . $run{'workshop-dir'} . "/userenvs/" . $userenv . ".json" .


### PR DESCRIPTION
- While this should not be problem, occasionally it does cause an
  error in the workship build process, which are probably due to outside
  factors beyond our control.  So for now, we will not do things like
  "dnf update" when building workshop images.