### PR TITLE
When a test abort is detected, exit with code 1

### DIFF
--- a/rickshaw-run
+++ b/rickshaw-run
@@ -1208,4 +1208,5 @@ put_json_file($run_file, \%run, $run_schema_file);
 if (defined $abort_test_id) {
     printf "WARNING: test %s was aborted. and all subsequent tests were not attempted.  " .
            "Run is incomplete\n", $abort_test_id;
+    exit 1;
 }


### PR DESCRIPTION
-scripts running rickshaw-run will know to not call post-processing scripts
 with non-zero exit code.