### PR TITLE
rickshaw-run: bug fixes in dump_params

### DIFF
--- a/rickshaw-post-process-bench
+++ b/rickshaw-post-process-bench
@@ -50,10 +50,14 @@ sub dump_params {
     foreach my $param (@{ $params_ref }) {
         my $arg = $$param{'arg'};
         my $val = $$param{'val'};
-        if (defined $cs_id) {
-            $val =~ s/\%client-id\%/$cs_id/;
-        }
+        if (defined $val && length $val) {
+            if (defined $cs_id) {
+                $val =~ s/\%client-id\%/$cs_id/;
+            }
             $params_str .= " --" . $arg . "=" . $val;
+        } else {
+            $params_str .= " --" . $arg;
+        }
     }
     $params_str =~ s/^\s//;
     return $params_str;

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -178,10 +178,14 @@ sub dump_params {
     foreach my $param (@{ $params_ref }) {
         my $arg = $$param{'arg'}; 
         my $val = $$param{'val'};
-        if (defined $cs_id) {
-            $val =~ s/\%client-id\%/$cs_id/;
-        }
+        if (defined $val && length $val) {
+            if (defined $cs_id) {
+                $val =~ s/\%client-id\%/$cs_id/;
+            }
             $params_str .= " --" . $arg . "=" . $val;
+        } else {
+            $params_str .= " --" . $arg;
+	}
     }
     $params_str =~ s/^\s//;
     return $params_str;


### PR DESCRIPTION
- The output from multiplex.go produces 'value' and not 'val'.

- Detect whether a parameter has a value or not and act accordingly.