### PR TITLE
rickshaw-run: set the client-server container images to expire after …

### DIFF
--- a/rickshaw-run
+++ b/rickshaw-run
@@ -346,7 +346,8 @@ sub build_container_image {
                         },
                         'config' => {
                             #'entrypoint' => [ "/bin/sh", "-c", "/usr/local/bin/client-server-script" ]
-                            'entrypoint' => [ "/bin/sh", "-c", "/usr/local/bin/bootstrap" ]
+                            'entrypoint' => [ "/bin/sh", "-c", "/usr/local/bin/bootstrap" ],
+                            'labels' => [ 'quay.expires-after=2w' ]
                         }
                     );
         my $cs_req_file = $config_dir . "/cs-req.json";


### PR DESCRIPTION
…2 weeks

- This affects the image's lifecycle in a container image registry
  such as quay.io