### PR TITLE
Fixes for trafficgen

### DIFF
--- a/rickshaw-export
+++ b/rickshaw-export
@@ -53,7 +53,12 @@ sub export_metric {
     my %metr_desc_doc = %$base_doc_ref;
     $metr_desc_doc{'metric_desc'} = $$metr_ref{'desc'};
     $metr_desc_doc{'metric_desc'}{'id'} = Data::UUID->new->create_str();
-    $metr_desc_doc{'metric_desc'}{'names'} = $$metr_ref{'names'};
+    if ( exists $$metr_ref{'names'} ) {
+        $metr_desc_doc{'metric_desc'}{'names'} = $$metr_ref{'names'};
+    }
+    if ( exists $$metr_ref{'values'} ) {
+        $metr_desc_doc{'metric_desc'}{'values'} = $$metr_ref{'values'};
+    }
     my $metr_desc_doc_json = $coder->encode(\%metr_desc_doc);
     http_request("POST", "localhost:9200", "/cdmv5dev-metric_desc/_doc/", $metr_desc_doc_json);
     my $count = 0;

--- a/rickshaw-post-process-consolidate
+++ b/rickshaw-post-process-consolidate
@@ -57,6 +57,12 @@ sub dedup_metric {
     my $first_begin;
     my $last_end;
     return (-1, -1) if ($num_samples == 0);
+    if (scalar @{ $$metric_ref{'data'} } == 1) {
+        # There is only one sample, so no need to consoldate
+        $$metric_ref{'data'}[0]{'duration'} = int $$metric_ref{'data'}[0]{'end'} -
+                                                    $$metric_ref{'data'}[0]{'begin'} + 1;
+        return ( int $$metric_ref{'data'}[0]{'begin'}, int $$metric_ref{'data'}[0]{'end'} );
+    }
     if (! defined $$metric_ref{'data'}[1]{'end'}) {
         print "[ERROR]could not find second sample for metric\n";
         print Dumper $$metric_ref{'desc'};

--- a/schema/bench-metric.json
+++ b/schema/bench-metric.json
@@ -58,11 +58,16 @@
                       "type": "string",
                       "pattern": "^.*$"
                     },
+                    "value-format": {
+                      "type": "string",
+                      "pattern": "^.*$"
+                    },
                     "class": {
                       "type": "string",
                       "enum": [
                         "throughput",
-                        "count"
+                        "count",
+                        "pass/fail"
                       ]
                     }
                   },
@@ -77,8 +82,14 @@
                 "names": {
                   "type": "object",
                   "propertyNames": {
-                    "pattern": "^[A-Za-z_-][A-Za-z0-9_\\-]*$"
-                  }
+                     "pattern": "^[A-Za-z_-][A-Za-z0-9_\\-]*$"
+                   }
+                },
+                "values": {
+                  "type": "object",
+                  "propertyNames": {
+                     "pattern": "^[A-Za-z_-][A-Za-z0-9_\\-]*$"
+                   }
                 },
                 "data": {
                   "type": "array",

--- a/schema/result.json
+++ b/schema/result.json
@@ -91,11 +91,16 @@
                                   "type": "string",
                                   "pattern": "^.*$"
                                 },
+                                "value-format": {
+                                  "type": "string",
+                                  "pattern": "^.*$"
+                                },
                                 "class": {
                                   "type": "string",
                                   "enum": [
                                     "throughput",
-                                    "count"
+                                    "count",
+                                    "pass/fail"
                                   ]
                                 }
                               },
@@ -108,6 +113,12 @@
                               "additionalProperties": false
                             },
                             "names": {
+                              "type": "object",
+                              "propertyNames": {
+                                "pattern": "^[A-Za-z_-][A-Za-z0-9_\\-]*$"
+                              }
+                            },
+                            "values": {
                               "type": "object",
                               "propertyNames": {
                                 "pattern": "^[A-Za-z_-][A-Za-z0-9_\\-]*$"
@@ -133,7 +144,9 @@
                                 },
                                 "required": [
                                   "value",
-                                  "end"
+                                  "begin",
+                                  "end",
+                                  "duration"
                                 ],
                                 "additionalProperties": false
                               },


### PR DESCRIPTION
-Properly post-process a metric with single sample
-Support the optional values-format for metrics
-Ensure processed metrics have all required fields
 including begin and duration.