### PR TITLE
Report any error message on roadblock abort

### DIFF
--- a/client-server-script
+++ b/client-server-script
@@ -644,10 +644,31 @@ if [ "$cs_type" == "client" -o "$cs_type" == "server" ]; then
                     fi
                     if [ $cmd_rc -gt 0 ]; then
                         echo -e "\nNon-zero exit code ($cmd_rc) from iteration $iter, sample $samp attempt $this_attempt_num"
+                        # An abort message must be sent so the other members know how to procede
+                        # Not necessary with server-stop since that is the last sync in this sample
                         if [ "$this_sync" != "server-stop" ]; then
-                            # An abort message must be sent so the other members know how to procede
-                            # Not necessary with server-stop since that is the last sync in this sample
                             abort_opt=" --abort"
+                            # Also send any messages. as we expect the benchmark scripts to send
+                            # details about why it had a non-zero exit code.
+                            pending_tx_msgs="`/bin/ls -1 $cs_tx_msgs_dir`"
+                            if [ ! -z "$pending_tx_msgs" ]; then
+                                echo "Found messages in $cs_tx_msgs_dir, preparing them to send"
+                                mkdir -p ${cs_tx_msgs_dir}-sent
+                                msgs_json_file="$iter_samp_dir/rb-msgs-$this_sync"
+                                echo "[" >"$msgs_json_file"
+                                for msg in $pending_tx_msgs; do
+                                    # TODO validate JSON schema
+                                    echo "Adding $msg to $msgs_json_file"
+                                    cat "$cs_tx_msgs_dir/$msg" >>"$msgs_json_file"
+                                    /bin/mv "$cs_tx_msgs_dir/$msg" "${cs_tx_msgs_dir}-sent"
+                                    echo "," >>"$msgs_json_file"
+                                done
+                                echo '{"recipient":{"type":"all","id":"all"},"user-object":{"sync":"'$this_sync'"}}]' >>$msgs_json_file
+                                echo "full message to send:"
+                                cat "$msgs_json_file"
+                                # TODO change this to $extra_opt everywhere
+                                abort_opt+=" --user-messages=$msgs_json_file"
+                            fi
                             echo -e "\nWill not continue this sample attempt and send abort message on next roadblock\n"
                         fi
                     fi

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -142,6 +142,7 @@ sub roadblock_leader {
             debug_log(sprintf "roadblock leader command:%s\n", $cmd);
             my $output = `$cmd`;
             $rc = $? & 127;
+            $_[0] = get_json_file($msgs_file);
             #printf "roadblock exit code: %d\n", $rc;
             # Becasue roadblock leader does not exit with right code
             if ( my $g_output = grep(/(Exiting\swith\sabort|Roadblock\sCompleted\swith\san\sAbort)/, $output) ) {
@@ -151,6 +152,12 @@ sub roadblock_leader {
                 printf "roadblock output BEGIN\n";
                 printf "%s", $output;
                 printf "roadblock output END\n";
+                printf "roadblock messages\n";
+                foreach my $msg (@{ $_[0]{'received'} }) {
+                    if (exists $$msg{'payload'}{'message'}{'user-object'} and exists $$msg{'payload'}{'message'}{'user-object'}{'error'}) {
+                        printf "\nError from %s:\n%s\n\n", $$msg{'payload'}{'sender'}{'id'}, $$msg{'payload'}{'message'}{'user-object'}{'error'};
+                    }
+                }
             }
             if ( my $g_output = grep(/(The\sroadblock\shas\stimed\sout|ERROR:\sRoadblock\sfailed\swith\stimeout)/, $output) ) {
                 #printf "Found:\n%s\n", $g_output;


### PR DESCRIPTION
-Any participant sending an abort can send a user-object "obort".
-This user object will be output by rickshaw-run
-This prevents the user from having to dig into a client/server's
 logs or files to find out what the error was.
-This abort message send is implemented in client-server-script
 after any non-zero return of client or server scripts
 (infra-start, client, server-start)
-Benchmark scripts, when detecting an error, should write
 the error message in ./msgs/tx/<error-msg> and exit with
 non-zero.
-We still need to add sending error messages in other places
 like endpoints and probably other areas of client-server-script.