### PR TITLE
Manage userenvs within rickshaw

### DIFF
--- a/rickshaw-run
+++ b/rickshaw-run
@@ -353,7 +353,7 @@ sub build_container_image {
         my $workshop_cmd = $run{'workshop-dir'} . "/workshop.pl" .
             # " --skip-update=true " .
             " --config " . $cs_conf_file .
-            " --userenv " . $run{'workshop-dir'} . "/userenvs/" . $userenv . ".json" .
+            " --userenv " . $rickshaw_project_dir . "/userenvs/" . $userenv . ".json" .
             " --requirements " . $run{'bench-dir'} . "/workshop.json" .
             " --requirements " . $cs_req_file .
             $workshop_roadblock_opt .
@@ -363,7 +363,7 @@ sub build_container_image {
                 $$tool_entry{'tool'} . "/workshop.json ";
         }
         my @config_analysis_output = `$workshop_cmd --label config-analysis --dump-config true`;
-        my $break_line;
+        my $break_line = 0;
         for (my $i=0; $i<scalar(@config_analysis_output); $i++) {
             if ($config_analysis_output[$i] =~ /Config dump:/) {
                 $break_line = $i;

--- a/userenvs/README
+++ b/userenvs/README
@@ -1,0 +1,18 @@
+The json files found in this directory can be built with build.sh:
+
+./build.sh $userenv
+
+where $userenv can be any directory name other than "components".
+
+For example:
+
+./build.sh fedora32
+
+Since there is lot of commonality among these user environemts,
+parts of their json come from common files under components.
+Each user env directory requires a schema.json, a userenv.json,
+and a requirements subdirectory with files for requirements.
+Any of these files can be symlinks to shared files in the
+components subdirectory.  Instaed of hand-editing a $userenv.json,
+change or add files in the ./$userenv directory and rerun the
+build command.

--- a/userenvs/build.sh
+++ b/userenvs/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "You must provide a directory"
+    exit
+fi
+
+userenv="$1"
+if [ ! -d "$userenv" ]; then
+    echo "Directory $userenv not found"
+    exit 1
+fi
+
+
+pushd "$userenv"
+echo "{" >../staging.json
+cat schema.json >>../staging.json
+cat userenv.json >>../staging.json
+pushd requirements
+echo '  "requirements": [' >>../../staging.json
+count=0
+for i in `/bin/ls -1`; do
+    if [ $count -gt 0 ]; then
+        echo ',' >>../../staging.json
+    fi
+    echo "found $i"
+    cat $i >>../../staging.json
+    let count=$count+1
+done
+popd
+echo ']' >>../staging.json
+echo '}' >>../staging.json
+popd
+jq . staging.json >$userenv.json && \
+/bin/rm staging.json
+

--- a/userenvs/centos7.json
+++ b/userenvs/centos7.json
@@ -1,0 +1,104 @@
+{
+  "workshop": {
+    "schema": {
+      "version": "2020.03.02"
+    }
+  },
+  "userenv": {
+    "name": "centos7",
+    "label": "CentOS 7",
+    "origin": {
+      "image": "registry.centos.org/centos/centos",
+      "tag": "7"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "yum"
+      }
+    }
+  },
+  "requirements": [
+    {
+      "name": "python3",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "python3",
+          "python3-pip"
+        ]
+      }
+    },
+    {
+      "name": "epel",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "epel-release"
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl",
+          "tar",
+          "cpio",
+          "xz",
+          "gzip",
+          "jq",
+          "git",
+          "cpio",
+          "findutils",
+          "hostname",
+          "iputils"
+        ]
+      }
+    },
+    {
+      "name": "core-compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "diffutils",
+          "gcc",
+          "libtool",
+          "autoconf",
+          "automake",
+          "make"
+        ]
+      }
+    },
+    {
+      "name": "extra-compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "flex",
+          "bison"
+        ]
+      }
+    },
+    {
+      "name": "iproute_src",
+      "type": "source",
+      "source_info": {
+        "url": "https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/iproute2-5.9.0.tar.xz",
+        "filename": "iproute2-5.9.0.tar.xz",
+        "commands": {
+          "unpack": "tar -xJf iproute2-5.9.0.tar.xz",
+          "get_dir": "tar -tJf iproute2-5.9.0.tar.xz| head -n 1",
+          "commands": [
+            "./configure",
+            "make",
+            "make install",
+            "ldconfig",
+            "/usr/sbin/ip -V"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/userenvs/centos7/requirements/01-python.json
+++ b/userenvs/centos7/requirements/01-python.json
@@ -1,0 +1,1 @@
+../../components/rpm-python3.json

--- a/userenvs/centos7/requirements/02-epel.json
+++ b/userenvs/centos7/requirements/02-epel.json
@@ -1,0 +1,9 @@
+    {
+      "name": "epel",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "epel-release"
+        ]
+      }
+    }

--- a/userenvs/centos7/requirements/03-core-utils.json
+++ b/userenvs/centos7/requirements/03-core-utils.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-utils-no-iproute.json

--- a/userenvs/centos7/requirements/04-core-compiling.json
+++ b/userenvs/centos7/requirements/04-core-compiling.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-compiling.json

--- a/userenvs/centos7/requirements/05-extra-compiling.json
+++ b/userenvs/centos7/requirements/05-extra-compiling.json
@@ -1,0 +1,1 @@
+../../components/rpm-extra-compiling.json

--- a/userenvs/centos7/requirements/06-iproute-src.json
+++ b/userenvs/centos7/requirements/06-iproute-src.json
@@ -1,0 +1,1 @@
+../../components/iproute-srcbuilt.json

--- a/userenvs/centos7/schema.json
+++ b/userenvs/centos7/schema.json
@@ -1,0 +1,1 @@
+../components/schema.json

--- a/userenvs/centos7/userenv.json
+++ b/userenvs/centos7/userenv.json
@@ -1,0 +1,14 @@
+  "userenv": {
+    "name": "centos7",
+    "label": "CentOS 7",
+    "origin": {
+      "image": "registry.centos.org/centos/centos",
+      "tag": "7"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "yum"
+      }
+    }
+  },

--- a/userenvs/centos8.json
+++ b/userenvs/centos8.json
@@ -1,0 +1,67 @@
+{
+  "workshop": {
+    "schema": {
+      "version": "2020.03.02"
+    }
+  },
+  "userenv": {
+    "name": "centos8",
+    "label": "CentOS 8",
+    "origin": {
+      "image": "registry.centos.org/centos/centos",
+      "tag": "8"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "dnf"
+      }
+    }
+  },
+  "requirements": [
+    {
+      "name": "python3",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "python3",
+          "python3-pip"
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl",
+          "tar",
+          "cpio",
+          "xz",
+          "gzip",
+          "jq",
+          "git",
+          "cpio",
+          "findutils",
+          "hostname",
+          "iputils",
+          "iproute"
+        ]
+      }
+    },
+    {
+      "name": "compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "diffutils",
+          "gcc",
+          "libtool",
+          "autoconf",
+          "automake",
+          "make"
+        ]
+      }
+    }
+  ]
+}

--- a/userenvs/centos8/requirements/01-python.json
+++ b/userenvs/centos8/requirements/01-python.json
@@ -1,0 +1,1 @@
+../../components/rpm-python3.json

--- a/userenvs/centos8/requirements/02-core-utils.json
+++ b/userenvs/centos8/requirements/02-core-utils.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-utils.json

--- a/userenvs/centos8/requirements/03-core-compiling.json
+++ b/userenvs/centos8/requirements/03-core-compiling.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-compiling.json

--- a/userenvs/centos8/schema.json
+++ b/userenvs/centos8/schema.json
@@ -1,0 +1,1 @@
+../components/schema.json

--- a/userenvs/centos8/userenv.json
+++ b/userenvs/centos8/userenv.json
@@ -1,0 +1,14 @@
+  "userenv": {
+    "name": "centos8",
+    "label": "CentOS 8",
+    "origin": {
+      "image": "registry.centos.org/centos/centos",
+      "tag": "8"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "dnf"
+      }
+    }
+  },

--- a/userenvs/components/convert-stream.json
+++ b/userenvs/components/convert-stream.json
@@ -1,0 +1,11 @@
+    {
+      "name": "stream-conversion",
+      "type": "manual",
+      "manual_info": {
+        "commands": [
+          "dnf -v -y install centos-release-stream",
+          "dnf -v -y swap centos-{linux,stream}-repos",
+          "dnf -v -y distro-sync"
+        ]
+      }
+    }

--- a/userenvs/components/deb-core-compiling.json
+++ b/userenvs/components/deb-core-compiling.json
@@ -1,0 +1,9 @@
+    {
+      "name": "compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "diffutils", "gcc", "libtool", "autoconf", "automake", "make"
+        ]
+      }
+    }

--- a/userenvs/components/deb-core-utils.json
+++ b/userenvs/components/deb-core-utils.json
@@ -1,0 +1,9 @@
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl", "tar", "cpio", "xz-utils", "gzip", "jq", "git", "cpio", "findutils", "hostname", "iputils-ping", "iproute"
+        ]
+      }
+    }

--- a/userenvs/components/debian-compiling.json
+++ b/userenvs/components/debian-compiling.json
@@ -1,0 +1,9 @@
+    {
+      "name": "compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "flex", "bison", "gcc", "libtool", "autoconf", "automake", "make", "libnuma-dev", "libnuma1"
+        ]
+      }
+    }

--- a/userenvs/components/debian-utils.json
+++ b/userenvs/components/debian-utils.json
@@ -1,0 +1,9 @@
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl", "tar", "cpio", "xz-utils", "gzip", "jq", "git", "cpio", "findutils", "hostname", "iputils-ping", "numactl"
+        ]
+      }
+    }

--- a/userenvs/components/iproute-srcbuilt.json
+++ b/userenvs/components/iproute-srcbuilt.json
@@ -1,0 +1,19 @@
+	    {
+	        "name": "iproute_src",
+	        "type": "source",
+	        "source_info": {
+		        "url": "https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/iproute2-5.9.0.tar.xz",
+		        "filename": "iproute2-5.9.0.tar.xz",
+		        "commands": {
+		            "unpack": "tar -xJf iproute2-5.9.0.tar.xz",
+		            "get_dir": "tar -tJf iproute2-5.9.0.tar.xz| head -n 1",
+		            "commands": [
+			            "./configure",
+			            "make",
+			            "make install",
+			            "ldconfig",
+			            "/usr/sbin/ip -V"
+		            ]
+                }
+	        }
+        }

--- a/userenvs/components/rh-alternatives-python.json
+++ b/userenvs/components/rh-alternatives-python.json
@@ -1,0 +1,10 @@
+    {
+      "name": "post-python",
+      "type": "manual",
+      "manual_info": {
+        "commands": [
+          "alternatives --install /usr/bin/python3 python3 /opt/rh/rh-python36/root/usr/bin/python3 1",
+          "alternatives --install /usr/bin/pip3 pip3 /opt/rh/rh-python36/root/usr/bin/pip3 1"
+        ]
+      }
+    }

--- a/userenvs/components/rh-python36.json
+++ b/userenvs/components/rh-python36.json
@@ -1,0 +1,10 @@
+    {
+      "name": "python3",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "rh-python36",
+          "rh-python36-python-pip"
+        ]
+      }
+    }

--- a/userenvs/components/rpm-core-compiling.json
+++ b/userenvs/components/rpm-core-compiling.json
@@ -1,0 +1,9 @@
+    {
+      "name": "core-compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "diffutils", "gcc", "libtool", "autoconf", "automake", "make"
+        ]
+      }
+    }

--- a/userenvs/components/rpm-core-utils-no-iproute.json
+++ b/userenvs/components/rpm-core-utils-no-iproute.json
@@ -1,0 +1,9 @@
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl", "tar", "cpio", "xz", "gzip", "jq", "git", "cpio", "findutils", "hostname", "iputils"
+        ]
+      }
+    }

--- a/userenvs/components/rpm-core-utils.json
+++ b/userenvs/components/rpm-core-utils.json
@@ -1,0 +1,9 @@
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl", "tar", "cpio", "xz", "gzip", "jq", "git", "cpio", "findutils", "hostname", "iputils", "iproute"
+        ]
+      }
+    }

--- a/userenvs/components/rpm-extra-compiling.json
+++ b/userenvs/components/rpm-extra-compiling.json
@@ -1,0 +1,9 @@
+    {
+      "name": "extra-compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "flex", "bison"
+        ]
+      }
+    }

--- a/userenvs/components/rpm-python3.json
+++ b/userenvs/components/rpm-python3.json
@@ -1,0 +1,10 @@
+    {
+      "name": "python3",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "python3",
+          "python3-pip"
+        ]
+      }
+    }

--- a/userenvs/components/schema.json
+++ b/userenvs/components/schema.json
@@ -1,0 +1,5 @@
+  "workshop": {
+    "schema": {
+      "version": "2020.03.02"
+    }
+  },

--- a/userenvs/components/src-extra-compiling.json
+++ b/userenvs/components/src-extra-compiling.json
@@ -1,0 +1,9 @@
+    {
+      "name": "src-compiling",
+      "type": "manual",
+      "distro_info": {
+        "packages": [
+          "flex", "bison", "libnuma"
+        ]
+      }
+    }

--- a/userenvs/components/utils-rpm.json
+++ b/userenvs/components/utils-rpm.json
@@ -1,0 +1,9 @@
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl", "tar", "cpio", "xz", "gzip", "jq", "git", "cpio", "findutils", "hostname", "iputils", "numactl"
+        ]
+      }
+    }

--- a/userenvs/debian.json
+++ b/userenvs/debian.json
@@ -1,0 +1,67 @@
+{
+  "workshop": {
+    "schema": {
+      "version": "2020.03.02"
+    }
+  },
+  "userenv": {
+    "name": "debian",
+    "label": "Debian",
+    "origin": {
+      "image": "docker.io/library/debian",
+      "tag": "stable-slim"
+    },
+    "properties": {
+      "packages": {
+        "type": "pkg",
+        "manager": "apt"
+      }
+    }
+  },
+  "requirements": [
+    {
+      "name": "python3",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "python3",
+          "python3-pip"
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl",
+          "tar",
+          "cpio",
+          "xz-utils",
+          "gzip",
+          "jq",
+          "git",
+          "cpio",
+          "findutils",
+          "hostname",
+          "iputils-ping",
+          "iproute"
+        ]
+      }
+    },
+    {
+      "name": "compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "diffutils",
+          "gcc",
+          "libtool",
+          "autoconf",
+          "automake",
+          "make"
+        ]
+      }
+    }
+  ]
+}

--- a/userenvs/debian/requirements/01-python.json
+++ b/userenvs/debian/requirements/01-python.json
@@ -1,0 +1,1 @@
+../../components/rpm-python3.json

--- a/userenvs/debian/requirements/02-core-utils.json
+++ b/userenvs/debian/requirements/02-core-utils.json
@@ -1,0 +1,1 @@
+../../components/deb-core-utils.json

--- a/userenvs/debian/requirements/03-core-compiling.json
+++ b/userenvs/debian/requirements/03-core-compiling.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-compiling.json

--- a/userenvs/debian/schema.json
+++ b/userenvs/debian/schema.json
@@ -1,0 +1,1 @@
+../components/schema.json

--- a/userenvs/debian/userenv.json
+++ b/userenvs/debian/userenv.json
@@ -1,0 +1,14 @@
+  "userenv": {
+    "name": "debian",
+    "label": "Debian",
+    "origin": {
+      "image": "docker.io/library/debian",
+      "tag": "stable-slim"
+    },
+    "properties": {
+      "packages": {
+        "type": "pkg",
+        "manager": "apt"
+      }
+    }
+  },

--- a/userenvs/fedora32.json
+++ b/userenvs/fedora32.json
@@ -1,0 +1,67 @@
+{
+  "workshop": {
+    "schema": {
+      "version": "2020.03.02"
+    }
+  },
+  "userenv": {
+    "name": "fedora32",
+    "label": "Fedora 32",
+    "origin": {
+      "image": "registry.fedoraproject.org/fedora",
+      "tag": "32"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "dnf"
+      }
+    }
+  },
+  "requirements": [
+    {
+      "name": "python3",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "python3",
+          "python3-pip"
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl",
+          "tar",
+          "cpio",
+          "xz",
+          "gzip",
+          "jq",
+          "git",
+          "cpio",
+          "findutils",
+          "hostname",
+          "iputils",
+          "iproute"
+        ]
+      }
+    },
+    {
+      "name": "compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "diffutils",
+          "gcc",
+          "libtool",
+          "autoconf",
+          "automake",
+          "make"
+        ]
+      }
+    }
+  ]
+}

--- a/userenvs/fedora32/requirements/01-python.json
+++ b/userenvs/fedora32/requirements/01-python.json
@@ -1,0 +1,1 @@
+../../components/rpm-python3.json

--- a/userenvs/fedora32/requirements/02-core-utils.json
+++ b/userenvs/fedora32/requirements/02-core-utils.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-utils.json

--- a/userenvs/fedora32/requirements/03-core-compiling.json
+++ b/userenvs/fedora32/requirements/03-core-compiling.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-compiling.json

--- a/userenvs/fedora32/schema.json
+++ b/userenvs/fedora32/schema.json
@@ -1,0 +1,1 @@
+../components/schema.json

--- a/userenvs/fedora32/userenv.json
+++ b/userenvs/fedora32/userenv.json
@@ -1,0 +1,14 @@
+  "userenv": {
+    "name": "fedora32",
+    "label": "Fedora 32",
+    "origin": {
+      "image": "registry.fedoraproject.org/fedora",
+      "tag": "32"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "dnf"
+      }
+    }
+  },

--- a/userenvs/fedora33.json
+++ b/userenvs/fedora33.json
@@ -1,0 +1,67 @@
+{
+  "workshop": {
+    "schema": {
+      "version": "2020.03.02"
+    }
+  },
+  "userenv": {
+    "name": "fedora33",
+    "label": "Fedora 33",
+    "origin": {
+      "image": "registry.fedoraproject.org/fedora",
+      "tag": "33"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "dnf"
+      }
+    }
+  },
+  "requirements": [
+    {
+      "name": "python3",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "python3",
+          "python3-pip"
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl",
+          "tar",
+          "cpio",
+          "xz",
+          "gzip",
+          "jq",
+          "git",
+          "cpio",
+          "findutils",
+          "hostname",
+          "iputils",
+          "iproute"
+        ]
+      }
+    },
+    {
+      "name": "compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "diffutils",
+          "gcc",
+          "libtool",
+          "autoconf",
+          "automake",
+          "make"
+        ]
+      }
+    }
+  ]
+}

--- a/userenvs/fedora33/requirements/01-python.json
+++ b/userenvs/fedora33/requirements/01-python.json
@@ -1,0 +1,1 @@
+../../components/rpm-python3.json

--- a/userenvs/fedora33/requirements/02-core-utils.json
+++ b/userenvs/fedora33/requirements/02-core-utils.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-utils.json

--- a/userenvs/fedora33/requirements/03-core-compiling.json
+++ b/userenvs/fedora33/requirements/03-core-compiling.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-compiling.json

--- a/userenvs/fedora33/schema.json
+++ b/userenvs/fedora33/schema.json
@@ -1,0 +1,1 @@
+../components/schema.json

--- a/userenvs/fedora33/userenv.json
+++ b/userenvs/fedora33/userenv.json
@@ -1,0 +1,14 @@
+  "userenv": {
+    "name": "fedora33",
+    "label": "Fedora 33",
+    "origin": {
+      "image": "registry.fedoraproject.org/fedora",
+      "tag": "33"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "dnf"
+      }
+    }
+  },

--- a/userenvs/opensuse.json
+++ b/userenvs/opensuse.json
@@ -1,0 +1,67 @@
+{
+  "workshop": {
+    "schema": {
+      "version": "2020.03.02"
+    }
+  },
+  "userenv": {
+    "name": "opensuse",
+    "label": "OpenSUSE Leap",
+    "origin": {
+      "image": "registry.opensuse.org/opensuse/leap",
+      "tag": "15"
+    },
+    "properties": {
+      "packages": {
+        "type": "pkg",
+        "manager": "zypper"
+      }
+    }
+  },
+  "requirements": [
+    {
+      "name": "python3",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "python3",
+          "python3-pip"
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl",
+          "tar",
+          "cpio",
+          "xz",
+          "gzip",
+          "jq",
+          "git",
+          "cpio",
+          "findutils",
+          "hostname",
+          "iputils",
+          "iproute"
+        ]
+      }
+    },
+    {
+      "name": "compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "diffutils",
+          "gcc",
+          "libtool",
+          "autoconf",
+          "automake",
+          "make"
+        ]
+      }
+    }
+  ]
+}

--- a/userenvs/opensuse/requirements/01-python.json
+++ b/userenvs/opensuse/requirements/01-python.json
@@ -1,0 +1,1 @@
+../../components/rpm-python3.json

--- a/userenvs/opensuse/requirements/02-core-utils.json
+++ b/userenvs/opensuse/requirements/02-core-utils.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-utils.json

--- a/userenvs/opensuse/requirements/03-core-compiling.json
+++ b/userenvs/opensuse/requirements/03-core-compiling.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-compiling.json

--- a/userenvs/opensuse/schema.json
+++ b/userenvs/opensuse/schema.json
@@ -1,0 +1,1 @@
+../components/schema.json

--- a/userenvs/opensuse/userenv.json
+++ b/userenvs/opensuse/userenv.json
@@ -1,0 +1,14 @@
+  "userenv": {
+    "name": "opensuse",
+    "label": "OpenSUSE Leap",
+    "origin": {
+      "image": "registry.opensuse.org/opensuse/leap",
+      "tag": "15"
+    },
+    "properties": {
+      "packages": {
+        "type": "pkg",
+        "manager": "zypper"
+      }
+    }
+  },

--- a/userenvs/rhubi7.json
+++ b/userenvs/rhubi7.json
@@ -1,0 +1,77 @@
+{
+  "workshop": {
+    "schema": {
+      "version": "2020.03.02"
+    }
+  },
+  "userenv": {
+    "name": "rhubi7",
+    "label": "Red Hat UBI 7",
+    "origin": {
+      "image": "registry.access.redhat.com/ubi7/ubi",
+      "tag": "latest"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "yum"
+      }
+    }
+  },
+  "requirements": [
+    {
+      "name": "python3",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "rh-python36",
+          "rh-python36-python-pip"
+        ]
+      }
+    },
+    {
+      "name": "post-python",
+      "type": "manual",
+      "manual_info": {
+        "commands": [
+          "alternatives --install /usr/bin/python3 python3 /opt/rh/rh-python36/root/usr/bin/python3 1",
+          "alternatives --install /usr/bin/pip3 pip3 /opt/rh/rh-python36/root/usr/bin/pip3 1"
+        ]
+      }
+    },
+    {
+      "name": "compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "diffutils",
+          "gcc",
+          "libtool",
+          "autoconf",
+          "automake",
+          "make"
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl",
+          "tar",
+          "cpio",
+          "xz",
+          "gzip",
+          "jq",
+          "git",
+          "cpio",
+          "findutils",
+          "hostname",
+          "iputils",
+          "iproute"
+        ]
+      }
+    }
+  ]
+}

--- a/userenvs/rhubi7/requirements/01-python.json
+++ b/userenvs/rhubi7/requirements/01-python.json
@@ -1,0 +1,1 @@
+../../components/rh-python36.json

--- a/userenvs/rhubi7/requirements/02-rh-alternatives-python.json
+++ b/userenvs/rhubi7/requirements/02-rh-alternatives-python.json
@@ -1,0 +1,1 @@
+../../components/rh-alternatives-python.json

--- a/userenvs/rhubi7/requirements/03-core-compiling.json
+++ b/userenvs/rhubi7/requirements/03-core-compiling.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-compiling.json

--- a/userenvs/rhubi7/requirements/04-core-utils.json
+++ b/userenvs/rhubi7/requirements/04-core-utils.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-utils.json

--- a/userenvs/rhubi7/rhubi7.json
+++ b/userenvs/rhubi7/rhubi7.json
@@ -1,0 +1,1 @@
+  "requirements":

--- a/userenvs/rhubi7/schema.json
+++ b/userenvs/rhubi7/schema.json
@@ -1,0 +1,1 @@
+../components/schema.json

--- a/userenvs/rhubi7/userenv.json
+++ b/userenvs/rhubi7/userenv.json
@@ -1,0 +1,14 @@
+  "userenv": {
+    "name": "rhubi7",
+    "label": "Red Hat UBI 7",
+    "origin": {
+      "image": "registry.access.redhat.com/ubi7/ubi",
+      "tag": "latest"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "yum"
+      }
+    }
+  },

--- a/userenvs/rhubi8.json
+++ b/userenvs/rhubi8.json
@@ -1,0 +1,67 @@
+{
+  "workshop": {
+    "schema": {
+      "version": "2020.03.02"
+    }
+  },
+  "userenv": {
+    "name": "rhubi8",
+    "label": "Red Hat UBI 8",
+    "origin": {
+      "image": "registry.access.redhat.com/ubi8/ubi",
+      "tag": "latest"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "yum"
+      }
+    }
+  },
+  "requirements": [
+    {
+      "name": "python3",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "python3",
+          "python3-pip"
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl",
+          "tar",
+          "cpio",
+          "xz",
+          "gzip",
+          "jq",
+          "git",
+          "cpio",
+          "findutils",
+          "hostname",
+          "iputils",
+          "iproute"
+        ]
+      }
+    },
+    {
+      "name": "compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "diffutils",
+          "gcc",
+          "libtool",
+          "autoconf",
+          "automake",
+          "make"
+        ]
+      }
+    }
+  ]
+}

--- a/userenvs/rhubi8/requirements/01-python.json
+++ b/userenvs/rhubi8/requirements/01-python.json
@@ -1,0 +1,1 @@
+../../components/rpm-python3.json

--- a/userenvs/rhubi8/requirements/02-core-utils.json
+++ b/userenvs/rhubi8/requirements/02-core-utils.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-utils.json

--- a/userenvs/rhubi8/requirements/03-core-compiling.json
+++ b/userenvs/rhubi8/requirements/03-core-compiling.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-compiling.json

--- a/userenvs/rhubi8/schema.json
+++ b/userenvs/rhubi8/schema.json
@@ -1,0 +1,1 @@
+../components/schema.json

--- a/userenvs/rhubi8/userenv.json
+++ b/userenvs/rhubi8/userenv.json
@@ -1,0 +1,14 @@
+  "userenv": {
+    "name": "rhubi8",
+    "label": "Red Hat UBI 8",
+    "origin": {
+      "image": "registry.access.redhat.com/ubi8/ubi",
+      "tag": "latest"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "yum"
+      }
+    }
+  },


### PR DESCRIPTION
-workshop would not track userenvs, only use them
-any project using workshop should manage its own userenvs
-included in this commit is a modular approach to build userenvs
 -use build.sh to regenerate userenv jsons