### PR TITLE
Update roadblock output handling

### DIFF
--- a/client-server-script
+++ b/client-server-script
@@ -91,7 +91,7 @@ function do_roadblock() {
             elif echo $output | grep -q -P -- '(The\sroadblock\shas\stimed\sout|Roadblock\sfailed\swith\stimeout)'; then
                 rc=$rb_exit_timeout
                 #rb_exit_msg="Roadblock error: $output"
-            elif echo $output | grep -q -p -- '(CRITICAL)'; then
+            elif echo $output | grep -q -P -- '(CRITICAL)'; then
                 rc=$rb_exit_critical
                 #rb_exit_msg="Roadblock error: $output"
             fi

--- a/client-server-script
+++ b/client-server-script
@@ -13,6 +13,7 @@ max_rb_attempts=5
 rb_exit_timeout=3
 rb_exit_abort=4
 rb_exit_nonet=5
+rb_exit_critical=6
 default_timeout=240
 client_server_script_timeout=720
 runtime_padding=180
@@ -78,7 +79,7 @@ function do_roadblock() {
             local output=`$cmd --uuid=$attempts:$uuid 2>&1`
             rc=$?
             echo "roadblock output BEGIN"
-            printf "%s" "$output"
+            printf "%s\n" "$output"
             echo "roadblock output END"
             echo "roadblock exit code: $rc"
             if echo $output | grep -q -P -- '(Name\sor\sservice\snot\sknown)'; then
@@ -87,8 +88,11 @@ function do_roadblock() {
             elif echo $output | grep -q -P -- '(Exiting\swith\sabort|Roadblock\sCompleted\swith\san\sAbort)'; then
                 rc=$rb_exit_abort
                 #rb_exit_msg="Roadblock error: $output"
-            elif echo $output | grep -q -P -- '(The\sroadblock\shas\stimed\sout|ERROR:\sRoadblock\sfailed\swith\stimeout)'; then
+            elif echo $output | grep -q -P -- '(The\sroadblock\shas\stimed\sout|Roadblock\sfailed\swith\stimeout)'; then
                 rc=$rb_exit_timeout
+                #rb_exit_msg="Roadblock error: $output"
+            elif echo $output | grep -q -p -- '(CRITICAL)'; then
+                rc=$rb_exit_critical
                 #rb_exit_msg="Roadblock error: $output"
             fi
             #if [ $rc -gt 0 ]; then

--- a/endpoints/base
+++ b/endpoints/base
@@ -286,7 +286,7 @@ function do_roadblock() {
             rc=$rb_exit_abort
         elif echo $output | grep -q -P -- '(The\sroadblock\shas\stimed\sout|Roadblock\sfailed\swith\stimeout)'; then
             rc=$rb_exit_timeout
-        elif echo $output | grep -q -p -- '(CRITICAL)'; then
+        elif echo $output | grep -q -P -- '(CRITICAL)'; then
             rc=$rc_exit_critical
         fi
     done

--- a/endpoints/base
+++ b/endpoints/base
@@ -11,6 +11,7 @@ controller_ipaddr=""
 rb_exit_timeout=3
 rb_exit_abort=4
 rb_exit_nonet=5
+rb_exit_critical=6
 default_timeout=240
 max_rb_attempts=5
 endpoint_deploy_timeout=360
@@ -275,7 +276,7 @@ function do_roadblock() {
         output=`$cmd --uuid $attempts:$uuid 2>&1`
         rc=$?
         echo "roadblock output BEGIN"
-        printf "%s" "$output"
+        printf "%s\n" "$output"
         echo "roadblock output END"
         echo "roadblock exit code: $rc"
 
@@ -283,8 +284,10 @@ function do_roadblock() {
             rc=$rb_exit_nonet
         elif echo $output | grep -q -P -- '(Exiting\swith\sabort|Roadblock\sCompleted\swith\san\sAbort)'; then
             rc=$rb_exit_abort
-        elif echo $output | grep -q -P -- '(The\sroadblock\shas\stimed\sout|ERROR:\sRoadblock\sfailed\swith\stimeout)'; then
+        elif echo $output | grep -q -P -- '(The\sroadblock\shas\stimed\sout|Roadblock\sfailed\swith\stimeout)'; then
             rc=$rb_exit_timeout
+        elif echo $output | grep -q -p -- '(CRITICAL)'; then
+            rc=$rc_exit_critical
         fi
     done
     echo "total attempts: $attempts"

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -87,6 +87,7 @@ my $bench_params_schema_file = $rickshaw_project_dir . "/schema/bench-params.jso
 my $roadblock_exit_timeout = 3;
 my $roadblock_exit_abort = 4;
 my $roadblock_exit_nofile = 5;
+my $roadblock_exit_critical = 6;
 my $max_rb_attempts = 5;
 
 my @tests;
@@ -195,18 +196,25 @@ sub roadblock_leader {
                     }
                 }
             }
-            if ( my $g_output = grep(/(The\sroadblock\shas\stimed\sout|ERROR:\sRoadblock\sfailed\swith\stimeout)/, $output) ) {
+	    my $g_output;
+            if ( $g_output = grep(/(The\sroadblock\shas\stimed\sout|Roadblock\sfailed\swith\stimeout)/, $output) ) {
                 #printf "Found:\n%s\n", $g_output;
                 #printf "%s", $output;
                 $rc = $roadblock_exit_timeout;
                 printf "roadblock output BEGIN\n";
                 printf "%s", $output;
                 printf "roadblock output END\n";
-            }
-            if ( my $g_output = grep(/(Could\snot\sopen\smessage\slog)/, $output) ) {
+            } elsif ( $g_output = grep(/(Could\snot\sopen\smessage\slog)/, $output) ) {
                 #printf "Found:\n%s\n", $g_output;
                 #printf "%s", $output;
                 $rc = $roadblock_exit_nofile;
+                printf "roadblock output BEGIN\n";
+                printf "%s", $output;
+                printf "roadblock output END\n";
+            } elsif ( $g_output = grep(/(CRITICAL)/, $output) ) {
+                #printf "Found:\n%s\n", $g_output;
+                #printf "%s", $output;
+                $rc = $roadblock_exit_critical;
                 printf "roadblock output BEGIN\n";
                 printf "%s", $output;
                 printf "roadblock output END\n";


### PR DESCRIPTION
- Recent changes in roadblock require updates to properly handle

- Properly format the printing of roadblock output so that it ends
  with a newline in shell scripts