### PR TITLE
Have all roadblocks lead by the controller

### DIFF
--- a/client-server-script
+++ b/client-server-script
@@ -303,14 +303,7 @@ function setup_core_env() {
     tool_cmds_dir="$config_dir/tool-cmds/$cs_type"
     run_dir="$base_run_dir/run"
     archives_dir="$run_dir/client-server/archives"
-
-    if [ "$cs_type" == "client" -o "$cs_type" == "server" ]; then 
-        sync_prefix=client-server
-        leader=controller
-    else
-        sync_prefix=collector
-        leader=endpoint
-    fi
+    sync_prefix=client-server
     sync=$sync_prefix-script-start
 }
 
@@ -347,12 +340,18 @@ function get_data() {
     done 9< "$cs_files_list"
 
     # Get the benchmark and tool commands
+    cs_start_bench_cmds="$cs_label-start-bench.cmds"
+    # Everyone gets the bench-start-cmds (the client's start cmds) because that tells everyone how many tests there are
     if [ "$cs_type" == "client" -o "$cs_type" == "server" ]; then
-        cs_start_bench_cmds="$cs_label-start-bench.cmds"
         scp_from_controller "$ssh_id_file" "$client_server_config_dir/bench-cmds/$cs_type/$cs_id/start" "bench-start-cmds"
-        if [ ! -e "bench-start-cmds" ]; then
-            abort_error "bench cmds file bench-start-cmds not found. PWD: `/bin/pwd`  LS: `/bin/ls`" $sync $leader
-        fi
+    else
+        # All tool-only osruntimes just copy from client-1
+        scp_from_controller "$ssh_id_file" "$client_server_config_dir/bench-cmds/client/1/start" "bench-start-cmds"
+    fi
+    if [ ! -e "bench-start-cmds" ]; then
+        abort_error "bench cmds file bench-start-cmds not found. PWD: `/bin/pwd`  LS: `/bin/ls`" $sync $leader
+    fi
+    if [ "$cs_type" == "client" -o "$cs_type" == "server" ]; then
         if [ "$cs_type" == "client" ]; then
             scp_from_controller "$ssh_id_file" "$client_server_config_dir/bench-cmds/$cs_type/$cs_id/infra" "bench-infra-cmds"
             if [ "$cs_id" == "1" ]; then
@@ -403,26 +402,29 @@ function run_tests() {
     # and put them in an array to later use.  At a
     # minimum, all clients and servers need a start
     # command, and all servers need a stop command
+    echo "Starting run_tests()"
     declare -A bench_runtime_cmds
     declare -A bench_infra_cmds
     declare -A bench_start_cmds
     declare -A bench_stop_cmds
+    echo "Processing bench cmds"
+    local count=0
+    if [ -e bench-start-cmds ]; then
+        while read -u 9 line; do
+            bench_start_cmds[$count]="$line"
+            let count=$count+1
+        done 9< bench-start-cmds
+    else
+        abort_error "bench-start-cmds not found" $sync $leader
+    fi
     if [ "$cs_type" == "client" -o "$cs_type" == "server" ]; then
-        local count=0
-        if [ -e bench-start-cmds ]; then
-            while read -u 9 line; do
-                bench_start_cmds[$count]="$line"
-                let count=$count+1
-            done 9< bench-start-cmds
-        else
-            abort_error "bench-start-cmds not found" $sync $leader
-        fi
         # Only the clients need a runtime and infra cmd
         if [ "$cs_type" == "client" ]; then
             count=0
             # Only generate runtime cmds for first client
             # as we assume all clients have the same runtime
             if [ -e bench-runtime-cmds -a "$cs_id" == 1 ]; then
+                echo "Loading bench runtime cmds"
                 while read -u 9 line; do
                     bench_runtime_cmds[$count]="$line"
                     let count=$count+1
@@ -432,6 +434,7 @@ function run_tests() {
             # Infra cmds are for clients that want/need
             # to do some work before the server starts
             if [ -e bench-infra-cmds ]; then
+                echo "Loading bench infra cmds"
                 while read -u 9 line; do
                     bench_infra_cmds[$count]="$line"
                     let count=$count+1
@@ -442,6 +445,7 @@ function run_tests() {
         # program finishes
         elif [ "$cs_type" == "server" ]; then
             if [ -e bench-stop-cmds ]; then
+                echo "Loading bench server cmds"
                 count=0
                 while read -u 9 line; do
                     bench_stop_cmds[$count]="$line"
@@ -453,162 +457,170 @@ function run_tests() {
         fi
     fi
 
-    local abort_opt=""
     # Run the actual tests by processing the commands array
-    if [ "$cs_type" == "client" -o "$cs_type" == "server" ]; then
-        abort_run_on_iter_fail=0
-        local timeout=$default_timeout
-        local len=${#bench_start_cmds[@]}
-        local quit=0
-        for (( i=0; i<$len; i++ )); do
-            local iter_samp=`echo ${bench_start_cmds[$i]} | awk '{print $1}'`
-            local iter=`echo $iter_samp | awk -F- '{print $1}'`
-            let iter_idx=$iter-1
-                sample_failures[$iter_idx]=0
-        done
-        for (( i=0; i<$len; i++ )); do
-            if [ $quit -gt 0 ]; then
-                echo "quit = 1 so breaking out of tests"
-                break
-            fi
-            local iter_samp=`echo ${bench_start_cmds[$i]} | awk '{print $1}'`
+    local abort_opt=""
+    echo "Going to process test roadblocks and bench cmds (if applicable)"
+    abort_run_on_iter_fail=0
+    local timeout=$default_timeout
+    local len=${#bench_start_cmds[@]}
+    local quit=0
+    for (( i=0; i<$len; i++ )); do
+        local iter_samp=`echo ${bench_start_cmds[$i]} | awk '{print $1}'`
+        local iter=`echo $iter_samp | awk -F- '{print $1}'`
+        let iter_idx=$iter-1
+            sample_failures[$iter_idx]=0
+    done
+    for (( i=0; i<$len; i++ )); do
+        if [ $quit -gt 0 ]; then
+            echo "quit = 1 so breaking out of tests"
+            break
+        fi
+        local iter_samp=`echo ${bench_start_cmds[$i]} | awk '{print $1}'`
+        if [ "$cs_type" == "client" -o "$cs_type" == "server" ]; then
+            local start_cmd=`echo ${bench_start_cmds[$i]} | sed -e s/^$iter_samp//`
+        fi
+        if [ "$cs_type" == "client" ]; then
             local start_cmd=`echo ${bench_start_cmds[$i]} | sed -e s/^$iter_samp//`
             local runtime_cmd=`echo ${bench_runtime_cmds[$i]} | sed -e s/^$iter_samp//`
             local infra_cmd=`echo ${bench_infra_cmds[$i]} | sed -e s/^$iter_samp//`
-            if [ "$cs_type" == "server" ]; then
-                stop_cmd=`echo ${bench_stop_cmds[$i]} | sed -e s/^$iter_samp//`
-            fi
-            local iter=`echo $iter_samp | awk -F- '{print $1}'`
-            let iter_idx=$iter-1
-            local samp=`echo $iter_samp | awk -F- '{print $2}'`
-            local iter_samp_dir="$cs_dir/iteration-$iter/sample-$samp"
-            local cs_msgs_dir="$iter_samp_dir/msgs"
-            local cs_tx_msgs_dir="$cs_msgs_dir/tx" # Messages a client or server wants to transmit
-            local cs_rx_msgs_dir="$cs_msgs_dir/rx" # Messages a client or server has received
-            local this_attempt_num=1
-            local sample_complete=0
-            while [ $sample_complete -eq 0 -a ${sample_failures[$iter_idx]} -lt $max_sample_failures ]; do
-                local this_attempt_fail=0
-                for this_dir in "$iter_samp_dir" "$cs_msgs_dir" "$cs_tx_msgs_dir" "$cs_rx_msgs_dir"; do
-                    echo "mkdir -p $this_dir"
-                    mkdir -p "$this_dir" || exit_error "Could not mkdir $this_dir"
-                done
-                # The following should be replaced by creating hardlinks in each sample
-                # dir for each file in $cs_file_list
+        elif [ "$cs_type" == "server" ]; then
+            stop_cmd=`echo ${bench_stop_cmds[$i]} | sed -e s/^$iter_samp//`
+        fi
+        local iter=`echo $iter_samp | awk -F- '{print $1}'`
+        let iter_idx=$iter-1
+        local samp=`echo $iter_samp | awk -F- '{print $2}'`
+        local iter_samp_dir="$cs_dir/iteration-$iter/sample-$samp"
+        local cs_msgs_dir="$iter_samp_dir/msgs"
+        local cs_tx_msgs_dir="$cs_msgs_dir/tx" # Messages a client or server wants to transmit
+        local cs_rx_msgs_dir="$cs_msgs_dir/rx" # Messages a client or server has received
+        local this_attempt_num=1
+        local sample_complete=0
+        while [ $sample_complete -eq 0 -a ${sample_failures[$iter_idx]} -lt $max_sample_failures ]; do
+            local this_attempt_fail=0
+            for this_dir in "$iter_samp_dir" "$cs_msgs_dir" "$cs_tx_msgs_dir" "$cs_rx_msgs_dir"; do
+                echo "mkdir -p $this_dir"
+                mkdir -p "$this_dir" || exit_error "Could not mkdir $this_dir"
+            done
+            # The following should be replaced by creating hardlinks in each sample
+            # dir for each file in $cs_file_list
+            if [ "$cs_type" == "client" -o "$cs_type" == "server" ]; then
                 find . -mindepth 1 -maxdepth 1 -type f | grep -v -- "$cs_label-stderrout.txt" | \
                     grep -v -- "$cs_label-bench.cmds" | grep -v -- "$cs_label-tool.cmds" | \
                     grep -v -- "$cs_files_list" | \
                     cpio -pdum iteration-$iter/sample-$samp/ ||
                     exit_error "Could not copy files from $cs_dir to $iter_samp_dir with find & cpio"
-                pushd $iter_samp_dir || exit_error "Could not chdir to $iter_samp_dir"
-                echo PWD: `/bin/pwd`
-                printf "Sample %d attempt number %d\n" $samp $this_attempt_num
-                local syncs=""
-                local stop_syncs=""
-                abort_opt=""
-                for start_stop in "start" "stop"; do
+            fi
+            pushd $iter_samp_dir || exit_error "Could not chdir to $iter_samp_dir"
+            echo PWD: `/bin/pwd`
+            printf "Sample %d attempt number %d\n" $samp $this_attempt_num
+            local syncs=""
+            local stop_syncs=""
+            abort_opt=""
+            for start_stop in "start" "stop"; do
+                if [ "$start_stop" == "start" ]; then
+                    syncs="infra server endpoint client"
+                else
+                    syncs="$stop_syncs"
+                fi
+                for sync in $syncs; do
+                    local this_sync="$sync-$start_stop"
                     if [ "$start_stop" == "start" ]; then
-                        syncs="infra server endpoint client"
-                    else
-                        syncs="$stop_syncs"
+                        # Build the syncs needed for stop, may end up being fewer than all syncs if start syncs abort early
+                        stop_syncs="$sync $stop_syncs"
                     fi
-                    for sync in $syncs; do
-                        local this_sync="$sync-$start_stop"
+                    local label="${iter}-${samp}-${this_attempt_num}:$this_sync"
+                    local msgs_file="$roadblock_msgs_dir/$label.json"
+                    local this_timeout=$default_timeout
+                    # Conditional below restricts to first client because we assume the runtime is the same for all clients
+                    if [ ! -z "$runtime_cmd" -a "$cs_type" == "client" -a "$this_sync" == "client-start" -a "$cs_id" == "1" -a "$abort_opt" == "" ]; then
+                        user_message_opt=""
+                        # Get estimated runtime if possible and send to everyone else
+                        # The script called must output in stdout the number of seconds the runtime should be
+                        echo "going to run this command to get the runtime: $runtime_cmd"
+                        runtime=`$runtime_cmd`
+                        if [ $? -eq 0  -a ! -z "$runtime" ]; then
+                            # Add padding to benchmark runtime to give
+                            # enough time for everyone to call roadblock
+                            let this_timeout=$runtime+$runtime_padding
+                            user_json_file="`mktemp`"
+                            # Sending timeout to all participants, to be used for clint-stop roadblock
+                            echo "adding timeout message to $cs_tx_msgs_dir"
+                            echo '{"recipient":{"type":"all","id":"all"},"user-object":{"timeout":"'$this_timeout'"}}' >"$cs_tx_msgs_dir/timeout"
+                        fi
+                    fi
+                    local pending_tx_msgs="`/bin/ls -1 $cs_tx_msgs_dir`"
+                    if [ ! -z "$pending_tx_msgs" -a "$abort_opt" == "" ]; then
+                        echo "Found messages in $cs_tx_msgs_dir, preparing them to send"
+                        mkdir -p ${cs_tx_msgs_dir}-sent
+                        local msgs_json_file="$iter_samp_dir/rb-msgs-$this_sync"
+                        echo "[" >"$msgs_json_file"
+                        for msg in $pending_tx_msgs; do
+                            # TODO validate JSON schema
+                            echo "Adding $msg to $msgs_json_file"
+                            cat "$cs_tx_msgs_dir/$msg" >>"$msgs_json_file"
+                            /bin/mv "$cs_tx_msgs_dir/$msg" "${cs_tx_msgs_dir}-sent"
+                            echo "," >>"$msgs_json_file"
+                        done
+                        echo '{"recipient":{"type":"all","id":"all"},"user-object":{"sync":"'$this_sync'"}}]' >>$msgs_json_file
+                        echo "full message to send:"
+                        cat "$msgs_json_file"
+                        # TODO changing this to $extra_opt everywhere
+                        abort_opt=" --user-messages=$msgs_json_file"
+                    fi
+                    do_roadblock "$label" "controller" $timeout "$abort_opt"
+                    local rb_rc=$?
+                    local cmd_rc=0
+                    abort_opt=""
+                    echo roadblock $label exit code: $rb_rc
+                    if [ $rb_rc -eq $rb_exit_abort ]; then
+                        this_attempt_fail=1
+                        let sample_failures[$iter_idx]=${sample_failures[$iter_idx]}+1
+                        echo -e "\nReceived abort exit code from iteration $iter, sample $samp roadblock"
+                        if [ ${sample_failures[$iter_idx]} -ge $max_sample_failures ]; then
+                            sample_complete=1
+                            printf "[ERROR]All A maximum of %d failures for iteration %d have been reached, failing this iteration\n" \
+                                $max_sample_failures $iter
+                        fi
+                        if [ $abort_run_on_iter_fail -eq 1 ]; then
+                            printf "[ERROR]Since this interation failed, skipping all other tests\n"
+                            quit=1
+                        fi
                         if [ "$start_stop" == "start" ]; then
-                            # Build the syncs needed for stop, may end up being fewer than all syncs if start syncs abort early
-                            stop_syncs="$sync $stop_syncs"
+                            # There is no reason to continue the rest of the start syncs because of the abort.
+                            # Since the list of stop syncs are constructed as start syncs are processed,
+                            # only the minimum nummber of stop syncs will be processed.  For example,
+                            # if server-start had an abort, only server-stop would be in the list of 
+                            # stop-syncs.  Or, if endpoint-start had an abort, both endpiont-stop and
+                            # server-stop would be in the list of stop syncs.
+                            break
                         fi
-                        local label="${iter}-${samp}-${this_attempt_num}:$this_sync"
-                        local msgs_file="$roadblock_msgs_dir/$label.json"
-                        local this_timeout=$default_timeout
-                        # Conditional below restricts to first client because we assume the runtime is the same for all clients
-                        if [ ! -z "$runtime_cmd" -a "$this_sync" == "client-start" -a "$cs_id" == "1" -a "$abort_opt" == "" ]; then
-                            user_message_opt=""
-                            # Get estimated runtime if possible and send to everyone else
-                            # The script called must output in stdout the number of seconds the runtime should be
-                            echo "going to run this command to get the runtime: $runtime_cmd"
-                            runtime=`$runtime_cmd`
-                            if [ $? -eq 0  -a ! -z "$runtime" ]; then
-                                # Add padding to benchmark runtime to give
-                                # enough time for everyone to call roadblock
-                                let this_timeout=$runtime+$runtime_padding
-                                user_json_file="`mktemp`"
-                                # Sending timeout to all participants, to be used for clint-stop roadblock
-                                echo "adding timeout message to $cs_tx_msgs_dir"
-                                echo '{"recipient":{"type":"all","id":"all"},"user-object":{"timeout":"'$this_timeout'"}}' >"$cs_tx_msgs_dir/timeout"
-                            fi
-                        fi
-                        local pending_tx_msgs="`/bin/ls -1 $cs_tx_msgs_dir`"
-                        if [ ! -z "$pending_tx_msgs" -a "$abort_opt" == "" ]; then
-                            echo "Found messages in $cs_tx_msgs_dir, preparing them to send"
-                            mkdir -p ${cs_tx_msgs_dir}-sent
-                            local msgs_json_file="$iter_samp_dir/rb-msgs-$this_sync"
-                            echo "[" >"$msgs_json_file"
-                            for msg in $pending_tx_msgs; do
-                                # TODO validate JSON schema
-                                echo "Adding $msg to $msgs_json_file"
-                                cat "$cs_tx_msgs_dir/$msg" >>"$msgs_json_file"
-                                /bin/mv "$cs_tx_msgs_dir/$msg" "${cs_tx_msgs_dir}-sent"
-                                echo "," >>"$msgs_json_file"
-                            done
-                            echo '{"recipient":{"type":"all","id":"all"},"user-object":{"sync":"'$this_sync'"}}]' >>$msgs_json_file
-                            echo "full message to send:"
-                            cat "$msgs_json_file"
-                            # TODO changing this to $extra_opt everywhere
-                            abort_opt=" --user-messages=$msgs_json_file"
-                        fi
-                        do_roadblock "$label" "controller" $timeout "$abort_opt"
-                        local rb_rc=$?
-                        local cmd_rc=0
-                        abort_opt=""
-                        echo roadblock $label exit code: $rb_rc
-                        if [ $rb_rc -eq $rb_exit_abort ]; then
-                            this_attempt_fail=1
-                            let sample_failures[$iter_idx]=${sample_failures[$iter_idx]}+1
-                            echo -e "\nReceived abort exit code from iteration $iter, sample $samp roadblock"
-                            if [ ${sample_failures[$iter_idx]} -ge $max_sample_failures ]; then
+                    else
+                        # Allow to break out of inner while loop if no aborts all the way to the last sync
+                        if [ $this_attempt_fail -eq 0 ]; then
+                            if [ "$this_sync" == "server-stop" ]; then
                                 sample_complete=1
-                                printf "[ERROR]All A maximum of %d failures for iteration %d have been reached, failing this iteration\n" \
-                                    $max_sample_failures $iter
-                            fi
-                            if [ $abort_run_on_iter_fail -eq 1 ]; then
-                                printf "[ERROR]Since this interation failed, skipping all other tests\n"
-                                quit=1
-                            fi
-                            if [ "$start_stop" == "start" ]; then
-                                # There is no reason to continue the rest of the start syncs because of the abort.
-                                # Since the list of stop syncs are constructed as start syncs are processed,
-                                # only the minimum nummber of stop syncs will be processed.  For example,
-                                # if server-start had an abort, only server-stop would be in the list of 
-                                # stop-syncs.  Or, if endpoint-start had an abort, both endpiont-stop and
-                                # server-stop would be in the list of stop syncs.
-                                break
-                            fi
-                        else
-                            # Allow to break out of inner while loop if no aborts all the way to the last sync
-                            if [ $this_attempt_fail -eq 0 ]; then
-                                if [ "$this_sync" == "server-stop" ]; then
-                                    sample_complete=1
-                                    let num_fail=$this_attempt_num-1
-                                    printf "Sample %d completed successfully with %d failed attempts (%d total sample failures for this iteration)\n" \
-                                        $samp $num_fail ${sample_failures[$iter_idx]}
-                                fi
+                                let num_fail=$this_attempt_num-1
+                                printf "Sample %d completed successfully with %d failed attempts (%d total sample failures for this iteration)\n" \
+                                    $samp $num_fail ${sample_failures[$iter_idx]}
                             fi
                         fi
-                        if [ $rb_rc -eq 2 ]; then
-                            exit_error "roadblock for client-server-start-test:$iter-$samp timed out"
+                    fi
+                    if [ $rb_rc -eq 2 ]; then
+                        exit_error "roadblock for client-server-start-test:$iter-$samp timed out"
+                    fi
+                    timeout=$default_timeout
+                    if [ -f $msgs_file ]; then
+                        local cs_buddy=""
+                        local count=1
+                        if [ $cs_type == "client" ]; then
+                            cs_buddy="server-$cs_id"
+                        elif [ $cs_type == "server" ]; then
+                            cs_buddy="client-$cs_id"
                         fi
-                        timeout=$default_timeout
-                        if [ -f $msgs_file ]; then
-                            local count=1
-                            if [ $cs_type == "client" ]; then
-                                cs_buddy="server-$cs_id"
-                            else
-                                cs_buddy="client-$cs_id"
-                            fi
-                            echo "Found messages file: $msgs_file"
-		                    # First look for a message to "all" but sent by client-server buddy
-		                    # (to be deprecated)
+                        echo "Found messages file: $msgs_file"
+                        # First look for a message to "all" but sent by client-server buddy
+                        # (to be deprecated)
+                        if [ "$cs_type" == "client" -o "$cs_type" == "server" ]; then
                             jq -cr '.received[] | select(.payload.sender.id == "'$cs_buddy'" and 
                                     .payload.message.command == "user-object") | .payload.message' $msgs_file\
                             | while read line; do
@@ -617,7 +629,7 @@ function run_tests() {
                                 echo "$line" | jq '."user-object"' >"$cs_rx_msgs_dir/$msg"
                                 let count=$count+1
                             done
-		                    # Next look for a message sent specifically to this client/server
+                            # Next look for a message sent specifically to this client/server
                             jq -cr '.received[] | select(.payload.recipient.id == "'$cs_label'" and 
                                     .payload.message.command == "user-object") | .payload.message' $msgs_file\
                             | while read line; do
@@ -626,76 +638,76 @@ function run_tests() {
                                 echo "$line" | jq '."user-object"' >"$cs_rx_msgs_dir/$msg"
                                 let count=$count+1
                             done
-                            # TODO: process the newly created msg files above instead of scanning the entire messages array again
-                            next_timeout=`jq -r '.received[] | .payload.message."user-object".timeout ' $msgs_file | grep -v null`
-                            jq -r '.received[] | .payload.message."user-object".timeout ' $msgs_file
-                            if [ ! -z "$next_timeout" ]; then
-                                echo "Applying timeout value of $next_timeout to next roadblock sync"
-                                timeout=$next_timeout
+                        fi
+                        # TODO: process the newly created msg files above instead of scanning the entire messages array again
+                        next_timeout=`jq -r '.received[] | .payload.message."user-object".timeout ' $msgs_file | grep -v null`
+                        jq -r '.received[] | .payload.message."user-object".timeout ' $msgs_file
+                        if [ ! -z "$next_timeout" ]; then
+                            echo "Applying timeout value of $next_timeout to next roadblock sync"
+                            timeout=$next_timeout
+                        fi
+                    fi
+                    # These combinations don't run a command:
+                    #  sync=infra-start & cs_type=server
+                    #  sync=server-start & cs_type=client
+                    #  sync=client-start & cs_type=server
+                    #  sync=server-stop & cs_type=client
+                    #  sync=infra-stop & cs_type=client|server
+                    if [ "$this_sync" == "infra-start" -a "$cs_type" == "client" -a ! -z "$infra_cmd" ]; then
+                        $infra_cmd
+                        cmd_rc=$?
+                    elif [ "$this_sync" == "server-start" -a "$cs_type" == "server" ]; then
+                        echo "Running $this_sync command: $start_cmd"
+                        $start_cmd
+                        cmd_rc=$?
+                    elif [ "$this_sync" == "client-start" -a "$cs_type" == "client" ]; then
+                        echo "Running $this_sync command: $start_cmd"
+                        $start_cmd
+                        cmd_rc=$?
+                    elif [ "$this_sync" == "server-stop" -a "$cs_type" == "server" ]; then
+                        echo "Running $this_sync command: $stop_cmd"
+                        $stop_cmd
+                        cmd_rc=$?
+                    fi
+                    if [ $cmd_rc -gt 0 ]; then
+                        echo -e "\nNon-zero exit code ($cmd_rc) from iteration $iter, sample $samp attempt $this_attempt_num"
+                        # An abort message must be sent so the other members know how to procede
+                        # Not necessary with server-stop since that is the last sync in this sample
+                        if [ "$this_sync" != "server-stop" ]; then
+                            abort_opt=" --abort"
+                            # Also send any messages. as we expect the benchmark scripts to send
+                            # details about why it had a non-zero exit code.
+                            pending_tx_msgs="`/bin/ls -1 $cs_tx_msgs_dir`"
+                            if [ ! -z "$pending_tx_msgs" ]; then
+                                echo "Found messages in $cs_tx_msgs_dir, preparing them to send"
+                                mkdir -p ${cs_tx_msgs_dir}-sent
+                                msgs_json_file="$iter_samp_dir/rb-msgs-$this_sync"
+                                echo "[" >"$msgs_json_file"
+                                for msg in $pending_tx_msgs; do
+                                    # TODO validate JSON schema
+                                    echo "Adding $msg to $msgs_json_file"
+                                    cat "$cs_tx_msgs_dir/$msg" >>"$msgs_json_file"
+                                    /bin/mv "$cs_tx_msgs_dir/$msg" "${cs_tx_msgs_dir}-sent"
+                                    echo "," >>"$msgs_json_file"
+                                done
+                                echo '{"recipient":{"type":"all","id":"all"},"user-object":{"sync":"'$this_sync'"}}]' >>$msgs_json_file
+                                echo "full message to send:"
+                                cat "$msgs_json_file"
+                                # TODO change this to $extra_opt everywhere
+                                abort_opt+=" --user-messages=$msgs_json_file"
                             fi
+                            echo -e "\nWill not continue this sample attempt and send abort message on next roadblock\n"
                         fi
-                        # These combinations don't run a command:
-                        #  sync=infra-start & cs_type=server
-                        #  sync=server-start & cs_type=client
-                        #  sync=client-start & cs_type=server
-                        #  sync=server-stop & cs_type=client
-                        #  sync=infra-stop & cs_type=client|server
-                        if [ "$this_sync" == "infra-start" -a "$cs_type" == "client" -a ! -z "$infra_cmd" ]; then
-                            $infra_cmd
-                            cmd_rc=$?
-                        elif [ "$this_sync" == "server-start" -a "$cs_type" == "server" ]; then
-                            echo "Running $this_sync command: $start_cmd"
-                            $start_cmd
-                            cmd_rc=$?
-                        elif [ "$this_sync" == "client-start" -a "$cs_type" == "client" ]; then
-                            echo "Running $this_sync command: $start_cmd"
-                            $start_cmd
-                            cmd_rc=$?
-                        elif [ "$this_sync" == "server-stop" -a "$cs_type" == "server" ]; then
-                            echo "Running $this_sync command: $stop_cmd"
-                            $stop_cmd
-                            cmd_rc=$?
-                        fi
-                        if [ $cmd_rc -gt 0 ]; then
-                            echo -e "\nNon-zero exit code ($cmd_rc) from iteration $iter, sample $samp attempt $this_attempt_num"
-                            # An abort message must be sent so the other members know how to procede
-                            # Not necessary with server-stop since that is the last sync in this sample
-                            if [ "$this_sync" != "server-stop" ]; then
-                                abort_opt=" --abort"
-                                # Also send any messages. as we expect the benchmark scripts to send
-                                # details about why it had a non-zero exit code.
-                                pending_tx_msgs="`/bin/ls -1 $cs_tx_msgs_dir`"
-                                if [ ! -z "$pending_tx_msgs" ]; then
-                                    echo "Found messages in $cs_tx_msgs_dir, preparing them to send"
-                                    mkdir -p ${cs_tx_msgs_dir}-sent
-                                    msgs_json_file="$iter_samp_dir/rb-msgs-$this_sync"
-                                    echo "[" >"$msgs_json_file"
-                                    for msg in $pending_tx_msgs; do
-                                        # TODO validate JSON schema
-                                        echo "Adding $msg to $msgs_json_file"
-                                        cat "$cs_tx_msgs_dir/$msg" >>"$msgs_json_file"
-                                        /bin/mv "$cs_tx_msgs_dir/$msg" "${cs_tx_msgs_dir}-sent"
-                                        echo "," >>"$msgs_json_file"
-                                    done
-                                    echo '{"recipient":{"type":"all","id":"all"},"user-object":{"sync":"'$this_sync'"}}]' >>$msgs_json_file
-                                    echo "full message to send:"
-                                    cat "$msgs_json_file"
-                                    # TODO change this to $extra_opt everywhere
-                                    abort_opt+=" --user-messages=$msgs_json_file"
-                                fi
-                                echo -e "\nWill not continue this sample attempt and send abort message on next roadblock\n"
-                            fi
-                        fi
-                    done #for syncs
-                done #for start/stop
-                if [ $this_attempt_fail -eq 1 ]; then
-                    /bin/mv "$iter_samp_dir" "$iter_samp_dir-fail${sample_failures[$iter_idx]}"
-                fi
-                let this_attempt_num=$this_attempt_num+1
-            done #while
-            popd >/dev/null  # from $iter_sampl_dir back to $cs_dir
-        done
-    fi
+                    fi
+                done #for syncs
+            done #for start/stop
+            if [ $this_attempt_fail -eq 1 ]; then
+                /bin/mv "$iter_samp_dir" "$iter_samp_dir-fail${sample_failures[$iter_idx]}"
+            fi
+            let this_attempt_num=$this_attempt_num+1
+        done #while
+        popd >/dev/null  # from $iter_sampl_dir back to $cs_dir
+    done #for all tests
 }
 
 function stop_tools() {
@@ -747,7 +759,7 @@ if [ $abort -eq 0 -a $? -eq 0 ]; then
             if [ $abort -eq 0 -a $? -eq 0 ]; then # start-tests rb passed
                 run_tests
             fi
-            do_roadblock $sync_prefix-stop-tests $leader 86400
+            do_roadblock $sync_prefix-stop-tests $leader $default_timeout
             do_roadblock $sync_prefix-stop-tools $leader $default_timeout
             stop_tools
         fi

--- a/endpoints/base
+++ b/endpoints/base
@@ -145,11 +145,9 @@ function addto_clients_servers() {
 }
 
 function echo_clients_servers() {
-    #if [ ${#clients[@]} -gt 0 ]; then
     if [ $num_clients -gt 0 ]; then
         echo "client ${!clients[@]}"
     fi
-    #if [ ${#servers[@]} -gt 0 ]; then
     if [ $num_servers -gt 0 ]; then
         echo "server ${!servers[@]}"
     fi
@@ -216,6 +214,7 @@ function do_roadblock() {
     local timeout=$1; shift
     if [ $# -gt 0 ]; then
         local message="$1"; shift # A file for user-messages or "" if none
+        echo "pwd: `/bin/pwd`"
         echo "Going to send this user message file: $message"
     else
         local message=""
@@ -305,43 +304,17 @@ function process_prebench_roadblocks() {
     if [ $? -eq $rb_exit_abort ]; then
         exit_error "Exiting due to abort from another participant"
     fi
-
-    if [ $# -gt 0 ]; then # followers were provided, so run these endpoint-leader syncs
-        do_roadblock "collector-script-start" "leader" $client_server_start_timeout "" $@
-        if [ $? -eq $rb_exit_abort ]; then
-            exit_error "Exiting due to abort from another participant"
-        fi
-    fi
-
     do_roadblock "client-server-script-start" "follower" $client_server_start_timeout
     if [ $? -eq $rb_exit_abort ]; then
         exit_error "Exiting due to abort from another participant"
-    fi
-
-    if [ $# -gt 0 ]; then # followers were provided, so run these endpoint-leader syncs
-        do_roadblock "collector-get-data" "leader" $client_server_start_timeout "" $@
-        if [ $? -eq $rb_exit_abort ]; then
-            exit_error "Exiting due to abort from another participant"
-        fi
     fi
     do_roadblock "client-server-get-data" "follower" $client_server_start_timeout
     if [ $? -eq $rb_exit_abort ]; then
         exit_error "Exiting due to abort from another participant"
     fi
-
-    if [ $# -gt 0 ]; then # followers were provided, so run these endpoint-leader syncs
-        do_roadblock "collector-start-tools" "leader" $default_timeout "" $@
-    fi
     do_roadblock "client-server-start-tools" "follower" $default_timeout
     if [ $? -eq $rb_exit_abort ]; then
         exit_error "Exiting due to abort from another participant"
-    fi
-
-    if [ $# -gt 0 ]; then # followers were provided, so run these endpoint-leader syncs
-        do_roadblock "collector-start-tests" "leader" $default_timeout "" $@
-        if [ $? -eq $rb_exit_abort ]; then
-            exit_error "Exiting due to abort from another participant"
-        fi
     fi
     do_roadblock "client-server-start-tests" "follower" $default_timeout
     if [ $? -eq $rb_exit_abort ]; then
@@ -511,8 +484,19 @@ function process_bench_roadblocks() {
 
 function process_roadblocks() {
     local endpoint_type=$1; shift
+    local new_followers="$@"
+    local msg_file=""
+    if [ ! -z "$new_followers" ]; then
+        echo "pwd: `/bin/pwd`"
+        msg_file="$endpoint_run_dir/new-followers.json"
+        echo "new_followers: $new_followers"
+        echo '[{"recipient":{"type":"all","id":"all"},"user-object":{"new-followers":[' >$msg_file
+        echo $new_followers | sed  -re 's/^\s+//' -re 's/\s+$//' -re 's/\s+/,/g' -re 's/([^,]+)/"\1"/g' >>$msg_file
+        echo ']}}]' >>$msg_file
+        echo "ls: `/bin/ls`"
+    fi
     if [ $abort -eq 0 ]; then
-        do_roadblock "endpoint-deploy" "follower" $endpoint_deploy_timeout
+        do_roadblock "endpoint-deploy" "follower" $endpoint_deploy_timeout $msg_file
         d_rc=$?
         echo "endpoint-deploy complete"
         if [ $abort -eq 0 -a $d_rc -eq 0 ]; then
@@ -531,12 +515,12 @@ function process_roadblocks() {
                 echo "this_sync: $this_sync"
                 stop_sync="`echo $this_sync | sed -e s/start/stop/ -e s/get/send/`"
                 echo "stop_sync: $stop_sync"
-                if [ $# -gt 0 ]; then # If there are no other args then there are no leader roadblocks
-                    echo "about to run do_roadblock collector-$this_sync leader $client_server_start_timeout "" $@"
-                    do_roadblock "collector-$this_sync" "leader" $client_server_start_timeout "" $@
-                    a_rb=$?
-                    echo "rb exit code: $a_rb"
-                fi
+                #if [ $# -gt 0 ]; then # If there are no other args then there are no leader roadblocks
+                    #echo "about to run do_roadblock collector-$this_sync leader $client_server_start_timeout "" $@"
+                    #do_roadblock "collector-$this_sync" "leader" $client_server_start_timeout "" $@
+                    #a_rb=$?
+                    #echo "rb exit code: $a_rb"
+                #fi
                 echo "about to run do_roadblock client-server-$this_sync follower $client_server_start_timeout"
                 do_roadblock "client-server-$this_sync" "follower" $client_server_start_timeout
                 b_rb=$?
@@ -591,20 +575,7 @@ function process_roadblocks() {
                     echo "going to signal client-server $client_abort_sync to abort"
                     do_roadblock "client-server-$client_abort_sync" "follower" "abort"
                 fi
-                if [ ! -z "$collector_abort_sync" ]; then
-                    echo "going to signal collector $collector_abort_sync to abort"
-                    do_roadblock "collector-$collector_abort_sync" "leader" "abort" "" $@
-                fi
             fi
-
-            echo "about to process collector stop syncs"
-            if [ $# -gt 0 ]; then # If there are no followers then no leader roadblocks
-                for (( i=0; i<${#collector_stop_syncs[*]}; i++ )); do
-                    this_sync="${collector_stop_syncs[$i]}"
-                    do_roadblock "collector-$this_sync" "leader" 86400 "" $@
-                done
-            fi
-
             echo "about to process client-server stop syncs"
             for (( i=0; i<${#client_stop_syncs[*]}; i++ )); do
                 this_sync="${client_stop_syncs[$i]}"
@@ -619,15 +590,6 @@ function process_roadblocks() {
         do_roadblock "endpoint-move-data" "follower" $endpoint_deploy_timeout
     fi
     do_roadblock "endpoint-finish" "follower" $endpoint_deploy_timeout
-}
-
-function process_postbench_roadblocks() {
-    for sub_label in stop-tools send-data script-finish; do
-        if [ $# -gt 0 ]; then # followers were provided, so run these endpoint-leader syncs
-            do_roadblock "collector-$sub_label" "leader" $default_timeout "" $@
-        fi
-        do_roadblock "client-server-$sub_label" "follower" $default_timeout
-    done
 }
 
 function process_final_roadblocks() {
@@ -648,9 +610,6 @@ function get_controller_ip() {
 
 function process_postbench_roadblocks() {
     for sub_label in stop-tools send-data script-finish; do
-        if [ $# -gt 0 ]; then # followers were provided, so run these endpoint-leader syncs
-            do_roadblock "collector-$sub_label" "leader" 86400 "" $@
-        fi
         do_roadblock "client-server-$sub_label" "follower" $default_timeout
     done
 }

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -1274,7 +1274,19 @@ sub process_roadblocks() {
     # progressed.  If at any point the pre-test-setup aborts, it is important to 
     # cleanup properly.  All roadblock particpants need the same conditional approach.
     # First confirm endpoints are deployed (all osruntimes have launched client-server-script)
+    my @new_followers;
     if (roadblock_leader("endpoint-deploy", $endpoint_deploy_timeout, $messages_ref, dump_endpoint_labels(\@endpoints)) == 0) {
+        # Endpoints may introduce new followers for remaining roadblocks.  These followers are typically osruntimes which
+        # are only running tools.
+        if (defined $messages_ref) {
+            foreach my $msg (@{ $$messages_ref{'received'} })  {
+                if (exists $$msg{'payload'}{'message'}{'user-object'}{'new-followers'}) {
+                    @new_followers = @{ $$msg{'payload'}{'message'}{'user-object'}{'new-followers'} };
+                    printf "New followers\n" . Dumper(\@new_followers);
+                    @rb_cs_ids = (@rb_cs_ids, @new_followers);
+                }
+            }
+        }
         # Next step all client-servers through pre-test preparation
         if (roadblock_leader("client-server-script-start", $client_server_script_timeout, $messages_ref, (@rb_cs_ids, dump_endpoint_labels(\@endpoints))) == 0) {
             if (roadblock_leader("client-server-get-data", $client_server_script_timeout, $messages_ref, (@rb_cs_ids, dump_endpoint_labels(\@endpoints))) == 0) {


### PR DESCRIPTION
-Don't have endpoints lead roadblocks for tool-only osruntimes
-Instead, have endpoints send new follower IDs to the controller
-Then controller knows about the new folowers
-Eliminates odd, 24-hour timeouts for some roadblocks