### PR TITLE
Add endpoint option to override controller_ip

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -597,26 +597,10 @@ function process_final_roadblocks() {
     do_roadblock endpoint-finish "follower" $default_timeout
 }
 
-function get_controller_ip() {
-    local host=$1; shift
-    local ip=`host $host | awk -F"address " '{print $2}'`
-    # TODO: confirm is valid ipv4 addr
-
-    # Now that we have the remote IP, figure out what IP this remote
-    # host will need to use to contact the controller
-    local controller_ipaddr=`ip route get $ip | head -1 | awk -F"src " '{print $2}' | awk '{print $1}'`
-    echo $controller_ipaddr
-}
-
 function process_postbench_roadblocks() {
     for sub_label in stop-tools send-data script-finish; do
         do_roadblock "client-server-$sub_label" "follower" $default_timeout
     done
-}
-
-function process_final_roadblocks() {
-    do_roadblock endpoint-move-data "follower" $endpoint_move_data_timeout
-    do_roadblock endpoint-finish "follower" $default_timeout
 }
 
 function get_controller_ip() {

--- a/endpoints/k8s/k8s
+++ b/endpoints/k8s/k8s
@@ -344,7 +344,12 @@ function process_k8s_opts() {
                 ;;
             host)
                 host=$val
-                controller_ipaddr=`get_controller_ip $host`
+                if [ -z "$controller_ipaddr" ]; then
+                    controller_ipaddr=`get_controller_ip $host`
+                fi
+                ;;
+            controller-ip)
+                controller_ipaddr=$val
                 ;;
             user)
                 user=$val

--- a/endpoints/remotehost/remotehost
+++ b/endpoints/remotehost/remotehost
@@ -218,7 +218,12 @@ function process_remotehost_opts() {
                 ;;
             host)
                 host=$val
-                controller_ipaddr=`get_controller_ip $host`
+               if [ -z "$controller_ipaddr" ]; then
+                    controller_ipaddr=`get_controller_ip $host`
+               fi
+                ;;
+            controller-ip)
+                controller_ipaddr=$val
                 ;;
             user)
                 user=$val


### PR DESCRIPTION
-the controller_ip is the IP address an osruntime uses to
 contact the controller.  This is normally determined automatically,
 but sometimes this is not so easy.  The user can now specify:
 "controller_ip:<ipaddr> on the endpont options to override the
 automatic determination of this IP.