### PR TITLE
only run ci jobs on pull requests, not pushes

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -2,8 +2,6 @@ name: crucible-ci
 
 on:
   # run on push or pull request events for the master branch only
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
- this avoids unneccessary runs of the ci