### PR TITLE
handle the case where an invalid reg-tls-verify value is encountered

### DIFF
--- a/rickshaw-run
+++ b/rickshaw-run
@@ -505,6 +505,9 @@ sub build_container_image {
         }
         if (! exists $run{'reg-tls-verify'}) {
             $run{'reg-tls-verify'} = "true";
+        } elsif ($run{'reg-tls-verify'} ne "true" && $run{'reg-tls-verify'} ne "false") {
+            printf "WARNING: Invalid value found for reg-tls-verify, defaulting to 'true'\n";
+            $run{'reg-tls-verify'} = "true";
         }
         my $tls_verify = "--tls-verify=" . $run{'reg-tls-verify'};
         if ($run{'reg-auth'} eq "") {


### PR DESCRIPTION
- this can happen if the Crucible config file has not been updated to
  include a value for $CRUCIBLE_CLIENT_SERVER_TLS_VERIFY.  In that
  scenario the code assumes that a value should be present so it uses
  it, which results in a blank/empty value being passed through.

- a more formal fix is required to update the Crucible config with new
  properties but in the meantime we should properly handle what
  happens if the value is not defined (or corrupted by the user,
  etc.).