### PR TITLE
detect and handle formating errors in json that is produced by the k8…

### DIFF
--- a/endpoints/k8s/k8s
+++ b/endpoints/k8s/k8s
@@ -71,9 +71,13 @@ declare -A volumeMounts
 function cleanup_json() {
     local json="$1"; shift
 
+    echo "cleanup_json: processing ${json}"
     mv ${json} ${json}.tmp
-    jq . ${json}.tmp > ${json}
-    rm ${json}.tmp
+    if jq . ${json}.tmp > ${json}; then
+        rm ${json}.tmp
+    else
+        exit_error "cleanup_json failed to process ${json}"
+    fi
 }
 
 function endpoint_k8s_test_stop() {


### PR DESCRIPTION
…s endpoint

- previously formating errors would be undetected and jq and the
  cleanup rm after it would wipe out all traces of the json that was
  produced

- now, detect jq errors and then exit accordingly, also only run the
  cleanup rm if the jq command completed successfully