### PR TITLE
properly convert client/server lists

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -132,7 +132,7 @@ fi
 function addto_clients_servers() {
     local arg="$1"; shift
     local val="$1"; shift
-    for ids in `echo $val | sed -e 's/,/ /'`; do
+    for ids in `echo $val | sed -e 's/+/ /g'`; do
         if echo $ids | grep -q -- "-"; then
             range=`echo $ids | sed 's/-/ /'`
             for j in `seq $range`; do


### PR DESCRIPTION
- We use a '+' to separate client/server lists since we cannot use a
  ',' -- the options are already ',' separated so we have to use
  something different

- Example: client:1+3,server:1+3