### PR TITLE
Add quiet mode to ssh commands for endpoints

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -23,6 +23,7 @@ num_clients=0
 num_servers=0
 abort=0
 max_sample_failures=""
+ssh_opts="-q -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 declare -A clients
 declare -A servers
 

--- a/endpoints/remotehost/remotehost
+++ b/endpoints/remotehost/remotehost
@@ -47,7 +47,6 @@ endpoint_name="remotehost"
 osruntime="chroot"
 userenv="rhubi8"
 user="root"
-ssh_opts="-o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 declare -A cpuPartitioning
 declare -A numaNode
 


### PR DESCRIPTION
-This does not affect k8s yet, as we have 'ssh' all over the
 place, and we (a) need to move do_ssh() to base file, and (b)
 have k8s use do_ssh if possible.#