### PR TITLE
Extend deploy and client-start timeouts

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -15,7 +15,7 @@ rb_exit_input=2
 default_timeout=240
 max_rb_attempts=""
 endpoint_deploy_timeout=360
-client_server_start_timeout=720
+client_server_script_start_timeout=720
 endpoint_move_data_timeout=300
 cs_rb_opts=""
 do_validate="0"
@@ -46,7 +46,7 @@ function exit_error() {
 function process_opts() {
     local longopts="validate,endpoint-opts:,endpoint-label:,run-id:,base-run-dir:,image:"
     local longopts+=",roadblock-server:,roadblock-passwd:,roadblock-id:,osruntime:,max-sample-failures:"
-    local longopts+=",max-rb-attempts:"
+    local longopts+=",max-rb-attempts:,endpoint-deploy-timeout:,client-server-script-start-timeout:"
     local opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
     if [ $? -ne 0 ]; then
         exit_error "Unrecognized option specified" endpoint-deploy  
@@ -103,6 +103,18 @@ function process_opts() {
             --max-rb-attempts)
                 shift;
                 max_rb_attempts="$1"
+                shift;
+                ;;
+            --endpoint-deploy-timeout)
+                shift;
+                endpoint_deploy_timeout="$1"
+                echo "setting endpoint_deploy_timeout to $endpoint_deploy_timeout"
+                shift;
+                ;;
+            --client-server-script-start-timeout)
+                shift;
+                client_server_script_start_timeout="$1"
+                echo "setting client_server_script_start_timeout to $client_server_script_start_timeout"
                 shift;
                 ;;
             --)
@@ -312,15 +324,15 @@ function process_prebench_roadblocks() {
     if [ $? -eq $rb_exit_abort ]; then
         exit_error "Exiting due to abort from another participant"
     fi
-    do_roadblock "client-server-script-start" "follower" $client_server_start_timeout
+    do_roadblock "client-server-script-start" "follower" $client_server_script_start_timeout
     if [ $? -eq $rb_exit_abort ]; then
         exit_error "Exiting due to abort from another participant"
     fi
-    do_roadblock "client-server-get-data" "follower" $client_server_start_timeout
+    do_roadblock "client-server-get-data" "follower" $default_timeout
     if [ $? -eq $rb_exit_abort ]; then
         exit_error "Exiting due to abort from another participant"
     fi
-    do_roadblock "client-server-collect-sysinfo" "follower" $client_server_start_timeout
+    do_roadblock "client-server-collect-sysinfo" "follower" $default_timeout
     if [ $? -eq $rb_exit_abort ]; then
         exit_error "Exiting due to abort from another participant"
     fi
@@ -531,14 +543,13 @@ function process_roadblocks() {
                     stop_sync="`echo $this_sync | sed -e s/start/stop/ -e s/get/send/`"
                     echo "stop_sync: $stop_sync"
                 fi
-                #if [ $# -gt 0 ]; then # If there are no other args then there are no leader roadblocks
-                    #echo "about to run do_roadblock collector-$this_sync leader $client_server_start_timeout "" $@"
-                    #do_roadblock "collector-$this_sync" "leader" $client_server_start_timeout "" $@
-                    #a_rb=$?
-                    #echo "rb exit code: $a_rb"
-                #fi
-                echo "about to run do_roadblock client-server-$this_sync follower $client_server_start_timeout"
-                do_roadblock "client-server-$this_sync" "follower" $client_server_start_timeout
+                if [ "$this_sync" == "script-start" ]; then
+                    this_timeout=$client_server_script_start_timeout
+                else
+                    this_timeout=$default_timeout
+                fi
+                echo "about to run do_roadblock client-server-$this_sync follower $this_timeout"
+                do_roadblock "client-server-$this_sync" "follower" $this_timeout
                 b_rb=$?
                 echo "rb exit code: $b_rb"
                 if [ $a_rb -gt 0 -a $b_rb -gt 0 ]; then
@@ -595,7 +606,7 @@ function process_roadblocks() {
             echo "about to process client-server stop syncs"
             for (( i=0; i<${#client_stop_syncs[*]}; i++ )); do
                 this_sync="${client_stop_syncs[$i]}"
-                do_roadblock "client-server-$this_sync" "follower" $client_server_start_timeout
+                do_roadblock "client-server-$this_sync" "follower" $client_server_script_start_timeout
             done
         else
             echo "deploy aborted, going directly to cleanup"

--- a/endpoints/k8s/k8s
+++ b/endpoints/k8s/k8s
@@ -679,6 +679,10 @@ function build_pod_spec() {
     echo "            \"value\": \"$max_rb_attempts\"" >>$json
     echo "          }," >>$json
     echo "          {" >>$json
+    echo "            \"name\": \"client_server_script_start_timeout\"," >>$json
+    echo "            \"value\": \"$client_server_script_start_timeout\"" >>$json
+    echo "          }," >>$json
+    echo "          {" >>$json
     echo "            \"name\": \"ssh_id\"," >>$json
     printf "            \"value\": \"" >>$json
     sed -z 's/\n/\\n/g' $config_dir/rickshaw_id.rsa >>$json

--- a/endpoints/remotehost/remotehost
+++ b/endpoints/remotehost/remotehost
@@ -420,6 +420,7 @@ function launch_osruntime() {
             base_cmd+=" --max-sample-failures=$max_sample_failures"
             base_cmd+=" --max-rb-attempts=$max_rb_attempts"
             base_cmd+=" --cpu-partitioning=$cpu_partitioning"
+            base_cmd+=" --client-server-script-start-timeout=$client_server_script_start_timeout"
             if [ $numa_node -gt -1 ]; then
                 base_cmd="numactl -N $numa_node -m $numa_node $base_cmd"
             fi

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -54,7 +54,7 @@ my $rb_bin = "/usr/local/bin/roadblock.py";
 my $messages_ref;
 my $default_rb_timeout = 240;
 my $endpoint_deploy_timeout = 360;
-my $client_server_script_timeout = 720;
+my $client_server_script_start_timeout = 720;
 my $endpoint_move_data_rb_timeout = 300;
 (my $hostname_cmd, my $hostname, my $hostname_rc) = run_cmd('hostname');
 chomp ($hostname);
@@ -1651,6 +1651,10 @@ sub deploy_endpoints() {
     # Deploy ths endpoints so they are ready to run benchmark and tools.
     # Each endpoint is responible for launching a osruntime for each client and server.
     print "Deploying endpoints\n";
+    $endpoint_deploy_timeout += scalar @endpoints * 120;
+    printf "endpoint-deploy-timeout adjusted to %d seconds\n", $endpoint_deploy_timeout;
+    $client_server_script_start_timeout += scalar @endpoints * 120;
+    printf "client-server-script-timeout adjusted to %d seconds\n", $endpoint_deploy_timeout;
     debug_log(sprintf "\nendpoint output:\n");
     for (my $i = 0; $i < scalar @endpoints; $i++) {
         my $type = $endpoints[$i]{'type'};
@@ -1674,6 +1678,8 @@ sub deploy_endpoints() {
                     " --base-run-dir=" . $run{'base-run-dir'} .
                     " --max-sample-failures=" . $run{'max-sample-failures'} .
                     " --max-rb-attempts=" . $run{'max-rb-attempts'} .
+                    " --endpoint-deploy-timeout=" . $endpoint_deploy_timeout .
+                    " --client-server-script-start-timeout=" . $client_server_script_start_timeout .
                     $endpoint_image_opt .
                     $endpoint_roadblock_opt .
                     " >" . $this_endpoint_run_dir . "/endpoint-stdout.txt" .
@@ -1721,9 +1727,9 @@ sub process_roadblocks() {
             }
         }
         # Next step all client-servers through pre-test preparation
-        if (roadblock_leader("client-server-script-start", $client_server_script_timeout, $messages_ref, (@rb_cs_ids, dump_endpoint_labels(\@endpoints))) == 0) {
-            if (roadblock_leader("client-server-get-data", $client_server_script_timeout, $messages_ref, (@rb_cs_ids, dump_endpoint_labels(\@endpoints))) == 0) {
-                if (roadblock_leader("client-server-collect-sysinfo", $client_server_script_timeout, $messages_ref, (@rb_cs_ids, dump_endpoint_labels(\@endpoints))) == 0) {
+        if (roadblock_leader("client-server-script-start", $client_server_script_start_timeout, $messages_ref, (@rb_cs_ids, dump_endpoint_labels(\@endpoints))) == 0) {
+            if (roadblock_leader("client-server-get-data", $client_server_script_start_timeout, $messages_ref, (@rb_cs_ids, dump_endpoint_labels(\@endpoints))) == 0) {
+                if (roadblock_leader("client-server-collect-sysinfo", $client_server_script_start_timeout, $messages_ref, (@rb_cs_ids, dump_endpoint_labels(\@endpoints))) == 0) {
                     if (roadblock_leader("client-server-start-tools", $default_rb_timeout, $messages_ref, (@rb_cs_ids, dump_endpoint_labels(\@endpoints))) == 0) {
                         if (roadblock_leader("client-server-start-tests", $default_rb_timeout, $messages_ref, (@rb_cs_ids, dump_endpoint_labels(\@endpoints))) == 0) {
                             # Now cycle through all tests


### PR DESCRIPTION
-timeouts are extended based on number of endpoints,
 which tends to increase time needed to pull container
 images.  client-server-script-start must be extended
 because some engines may start quite earlier than
 others.