### PR TITLE
fixup tool-params schema

### DIFF
--- a/schema/tool-params.json
+++ b/schema/tool-params.json
@@ -26,9 +26,18 @@
               "type": "string",
               "minLength": 1
             }
-          }
+          },
+          "required": [
+            "arg",
+            "val"
+          ],
+          "additionalProperties": false
         }
       }
-    }
+    },
+    "required": [
+      "tool"
+    ],
+    "additionalProperties": false
   }
 }


### PR DESCRIPTION
- without required properties it was possible to create incomplete
  tool-params, either by leaving out a property entirely or by typo

- similarly, when additionalProperties are enabled it is easy to make
  typos and not realize it because it accepts invalid properties