### PR TITLE
use a json file to provide a common settings library

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -12,11 +12,7 @@ rb_exit_success=0
 rb_exit_timeout=3
 rb_exit_abort=4
 rb_exit_input=2
-default_timeout=240
 max_rb_attempts=""
-endpoint_deploy_timeout=360
-client_server_script_start_timeout=720
-endpoint_move_data_timeout=300
 cs_rb_opts=""
 do_validate="0"
 num_clients=0
@@ -745,5 +741,35 @@ function get_controller_ip() {
     else
         echo ${controller_ip}
         return 0
+    fi
+}
+
+function load_json_setting() {
+    local query var value
+
+    query="$1"
+    typeset -n var=$2
+
+    echo "load_json_setting():"
+
+    value=$(${TOOLBOX_HOME}/bin/get-json-settings.pl --settings "${config_dir}/rickshaw-settings.json.xz" --query ${query})
+    if [ $? != 0 ]; then
+        echo "available json settings:"
+        xzcat ${json_settings_file}
+        exit_error "query '${query}' failed to load a json setting"
+    else
+        var=${value}
+        echo "json setting query '${query}' returned '${var}'"
+    fi
+
+    return 0
+}
+
+function load_settings() {
+    if [ "$do_validate" != 1 ]; then
+        load_json_setting "roadblock.timeouts.default" default_timeout
+        load_json_setting "roadblock.timeouts.endpoint-deploy" endpoint_deploy_timeout
+        load_json_setting "roadblock.timeouts.client-server-start" client_server_script_start_timeout
+        load_json_setting "roadblock.timeouts.move-data" endpoint_move_data_timeout
     fi
 }

--- a/endpoints/k8s/k8s
+++ b/endpoints/k8s/k8s
@@ -971,6 +971,7 @@ function endpoint_k8s_cleanup() {
 process_opts "$@"
 process_k8s_opts "$endpoint_opts"
 init_common_dirs
+load_settings
 k8s_req_check
 base_req_check
 get_k8s_config

--- a/endpoints/remotehost/remotehost
+++ b/endpoints/remotehost/remotehost
@@ -478,6 +478,7 @@ function endpoint_remotehost_cleanup() {
 process_opts $@
 process_remotehost_opts $endpoint_opts
 init_common_dirs
+load_settings
 remotehost_req_check
 base_req_check
 launch_osruntime

--- a/engine/bootstrap
+++ b/engine/bootstrap
@@ -218,6 +218,13 @@ else
 fi
 echo
 
+export json_settings_file="/tmp/rickshaw-settings.json.xz"
+
+scp_from_controller "$ssh_id_file" "$config_dir/rickshaw-settings.json.xz" /tmp
+if [ ! -e ${json_settings_file} ]; then
+    exit_error "Could not find rickshaw-settings.json.xz"
+fi
+
 scp_from_controller "$ssh_id_file" "$client_server_config_dir/client-server-script" /usr/local/bin/
 if [ -e /usr/local/bin/client-server-script ]; then
     echo "Execing client-server-script:"

--- a/engine/bootstrap
+++ b/engine/bootstrap
@@ -1,9 +1,11 @@
-#!/bin/bash
+#!/usr/local/bin/bash
 # -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
 # vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
 #
 # The following is the minimum amount of code to copy over the client-server-script and no more.
 exec 2>&1
+
+echo "BASH_VERSION=${BASH_VERSION}"
 
 # Some container images need this
 test -e /etc/profile && . /etc/profile

--- a/engine/client-server-script
+++ b/engine/client-server-script
@@ -1,7 +1,10 @@
-#!/bin/bash
+#!/usr/local/bin/bash
 # -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
 # vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
 exec 2>&1
+
+echo "BASH_VERSION=${BASH_VERSION}"
+
 test -e /etc/profile && . /etc/profile
 
 # Depending on how client-server-script is started, "/usr/local/bin" is not

--- a/engine/client-server-script
+++ b/engine/client-server-script
@@ -16,7 +16,6 @@ rb_exit_success=0
 rb_exit_timeout=3
 rb_exit_abort=4
 rb_exit_input=2
-default_timeout=240
 runtime_padding=180
 abort=0
 
@@ -239,9 +238,9 @@ function process_opts() {
                 ;;
         esac
     done
-if [ -z "$client_server_script_start_timeout" ]; then
-    client_server_script_start_timeout=720
-fi
+    if [ -z "$client_server_script_start_timeout" ]; then
+        load_json_setting "roadblock.timeouts.client-server-start" client_server_script_start_timeout
+    fi
 }
 
 function validate_core_env() {
@@ -778,8 +777,30 @@ function send_data() {
     archive_to_controller "$ssh_id_file" "$cs_dir" "$archives_dir/$cs_label-data.tgz"
 }
 
+function load_json_setting() {
+    local query var value
+
+    query="$1"
+    typeset -n var=$2
+
+    echo "load_json_setting():"
+
+    value=$(${TOOLBOX_HOME}/bin/get-json-settings.pl --settings ${json_settings_file} --query ${query})
+    if [ $? != 0 ]; then
+        echo "available json settings:"
+        xzcat ${json_settings_file}
+        exit_error "query '${query}' failed to load a json setting"
+    else
+        var=${value}
+        echo "json setting query '${query}' returned '${var}'"
+    fi
+
+    return 0
+}
+
 sync=client-server-script-start
 leader=controller
+load_json_setting "roadblock.timeouts.default" default_timeout
 process_opts
 validate_core_env
 setup_core_env # roadblocks may be used after this

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -32,6 +32,7 @@ use lib "$ENV{'TOOLBOX_HOME'}/perl";
 use toolbox::json;
 use toolbox::logging;
 use toolbox::run;
+use toolbox::jsonsettings;
 
 $toolbox::logging::debug = 0;
 
@@ -42,6 +43,7 @@ my %defaults = ( "num-samples" => 1, "tool-group" => "default", "test-order" => 
 
 my @utilities = ( "packrat" );
 
+my $jsonsettings;
 my $use_roadblock = 0;
 my $use_workshop = 0;
 my %bench_config;
@@ -52,10 +54,10 @@ my %run; # A multi-dimensional, nested hash, schema TBD
 my $redis_passwd = "flubber"; # TODO: make this cmdline setting
 my $rb_bin = "/usr/local/bin/roadblock.py";
 my $messages_ref;
-my $default_rb_timeout = 240;
-my $endpoint_deploy_timeout = 360;
-my $client_server_script_start_timeout = 720;
-my $endpoint_move_data_rb_timeout = 300;
+my $default_rb_timeout;
+my $endpoint_deploy_timeout;
+my $client_server_script_start_timeout;
+my $endpoint_move_data_rb_timeout;
 (my $hostname_cmd, my $hostname, my $hostname_rc) = run_cmd('hostname');
 chomp ($hostname);
 my $hostname_md5 = Digest::MD5->new;
@@ -715,6 +717,8 @@ sub build_reqs {
         exit 1;
     }
     push (@$req_ref, "--requirement " . $tb_req_file);
+    # The second toolbox req ensures the proper dependencies are installed
+    push (@$req_ref, "--requirement " . $ENV{'TOOLBOX_HOME'} .  "/workshop.json");
 
     if ($use_roadblock) {
         my $rb_script_req_file = $config_dir . "/roadblock-script-req.json";
@@ -1304,9 +1308,47 @@ sub make_run_dirs() {
     }
 }
 
+sub load_settings_info() {
+    (my $rc, $jsonsettings) = load_json_settings($rickshaw_project_dir . "/rickshaw-settings.json");
+    if ($rc != 0) {
+        print "load_settings_info(): load_json_settings() failed\n";
+        exit 1;
+    }
+
+    ($rc, $default_rb_timeout) = get_json_setting("roadblock.timeouts.default", $jsonsettings);
+    if ($rc != 0) {
+        print "load_settings_info(): failed to load default roadblock timeout\n";
+        exit 1;
+    }
+
+    ($rc, $endpoint_deploy_timeout) = get_json_setting("roadblock.timeouts.endpoint-deploy", $jsonsettings);
+    if ($rc != 0) {
+        print "load_settings_info(): failed to load endpoint-deploy roadblock timeout\n";
+        exit 1;
+    }
+
+    ($rc, $client_server_script_start_timeout) = get_json_setting("roadblock.timeouts.client-server-start", $jsonsettings);
+    if ($rc != 0) {
+        print "load_settings_info(): failed to load client-server-start roadblock timeout\n";
+        exit 1;
+    }
+
+    ($rc, $endpoint_move_data_rb_timeout) = get_json_setting("roadblock.timeouts.move-data", $jsonsettings);
+    if ($rc != 0 ) {
+        print "load_settings_info(): failed to load move-data roadblock timeout\n";
+        exit 1;
+    }
+}
+
 sub save_config_info() {
     if (put_json_file($config_dir . "/rickshaw-run.json", \%run) > 0) {
         printf "save_config_info(): put_json_file() failed for %s\n", $config_dir . "/rickshaw-run.json";
+        exit 1;
+    }
+
+    if (put_json_file($config_dir . "/rickshaw-settings.json", $jsonsettings) > 0) {
+        printf "save_config_info(): put_json_file() failed for %s\n", $config_dir . "/rickshaw-settings.json";
+        exit 1;
     }
 }
 
@@ -1948,6 +1990,7 @@ $workshop_base_cmd =
     " --param %rickshaw-dir%=" . $rickshaw_project_dir .
     " --reg-tls-verify=" . $run{'reg-tls-verify'} .
     " 2>&1";
+load_settings_info();
 save_config_info();
 validate_endpoints();
 build_test_order();

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -635,7 +635,51 @@ sub build_reqs {
     # that does not exist, we want to match an imagewith as many requirements
     # as possible and add only what we need.
 
-    # The most common requirment is expected to be the toolbox.
+    # The most common requirement is expected to be source built bash
+    # -- this provides a common bash feature set across all userenvs
+    my $bash_req_file = $config_dir . "/bash-req.json";
+    my %bash_req = (
+                    'workshop' => {
+                        'schema' => {
+                            'version' => '2020.03.02'
+                        }
+                    },
+                    'userenvs' => [
+                        {
+                            'name' => 'default',
+                            'requirements' => [
+                                'bash_src'
+                            ]
+                        }
+                    ],
+                    'requirements' => [
+                        {
+                            'name' => 'bash_src',
+                            'type' => 'source',
+                            'source_info' => {
+                                'url' => 'https://mirrors.ocf.berkeley.edu/gnu/bash/bash-5.1.tar.gz',
+                                'filename' => 'bash.tar.gz',
+                                'commands' => {
+                                    'unpack' => 'tar -xzf bash.tar.gz',
+                                    'get_dir' => 'tar -tzf bash.tar.gz | head -n 1',
+                                    'commands' => [
+                                        './configure --prefix=/usr/local',
+                                        'make',
+                                        'make install',
+                                        '/usr/local/bin/bash --version'
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                );
+    if (put_json_file($bash_req_file, \%bash_req) > 0) {
+        printf "build_container_image(): put_json_file() failed\n";
+        exit 1;
+    }
+    push (@$req_ref, "--requirement " . $bash_req_file);
+
+    # The next most common requirment is expected to be the toolbox.
     my $tb_req_file = $config_dir . "/toolbox-req.json";
     my %tb_req = (
                     'workshop' => {

--- a/rickshaw-settings.json
+++ b/rickshaw-settings.json
@@ -1,0 +1,10 @@
+{
+    "roadblock": {
+	"timeouts": {
+	    "default": 240,
+	    "endpoint-deploy": 360,
+	    "client-server-start": 720,
+	    "move-data": 300
+	}
+    }
+}


### PR DESCRIPTION
- this library is shared between rickshaw-run, the endpoint scripts,
  and client-server-script

- the settings are queried from the file using new functionality added
  to the toolbox project