### PR TITLE
do not force root privileges for k8s endpoint when using do_ssh

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -250,7 +250,9 @@ function do_ssh() {
     if [ -z "$host" ]; then
         exit_error "do_ssh: host was blank: $user_host"
     fi
-    if [ "$user" != "root" ]; then
+    # the k8s endpoint is the only endpoint (as of now) that doesn't
+    # force the user to have root privileges
+    if [ "${endpoint_name}" != "k8s" -a "${user}" != "root" ]; then
         ssh_cmd="ssh $ssh_opts $user_host sudo bash -c \"$@\""
     else
         ssh_cmd="ssh $ssh_opts $user_host $@"


### PR DESCRIPTION
- the k8s endpoint accesses the k8s cluster via an account on a
  "gateway" system with cluster privileges -- it does not require root
  privileges for this to work and using sudo to assume root privileges
  can actually break it (since the root user may not have the
  necessary privileges to access the cluster)