### PR TITLE
Allow for remotehost to just collect tools

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -17,12 +17,14 @@ cs_rb_opts=""
 do_validate="0"
 num_clients=0
 num_servers=0
+num_collectors=0
 disable_tools=0
 abort=0
 max_sample_failures=""
 export ssh_opts="-q -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 declare -A clients
 declare -A servers
+declare -A collectors # For a remotehost that has no client or server, but runs tools
 
 function abort_error() {
     local msg="$1"; shift
@@ -153,6 +155,9 @@ function addto_clients_servers() {
                 elif [ "$arg" == "servers" -o "$arg" == "server" ]; then
                     servers[$j]="server-$j"
                     let num_servers=$num_servers+1
+                elif [ "$arg" == "profiler" ]; then
+                    collectors[$j]="profiler-$j"
+                    let num_collectors=$num_collectors+1
                 fi
             done
         else
@@ -162,6 +167,9 @@ function addto_clients_servers() {
             elif [ "$arg" == "servers" -o "$arg" == "server" ]; then
                 servers[$ids]="server-$ids"
                 let num_servers=$num_servers+1
+            elif [ "$arg" == "profiler" ]; then
+                collectors[$ids]="profiler-$ids"
+                let num_collectors=$num_collectors+1
             fi
         fi
     done
@@ -173,6 +181,9 @@ function echo_clients_servers() {
     fi
     if [ $num_servers -gt 0 ]; then
         echo "server ${!servers[@]}"
+    fi
+    if [ $num_collectors -gt 0 ]; then
+        echo "profiler ${!collectors[@]}"
     fi
 }
 

--- a/endpoints/remotehost/remotehost
+++ b/endpoints/remotehost/remotehost
@@ -207,7 +207,7 @@ function process_remotehost_opts() {
         # The $val may have : in it, so don't use awk to get only the second field
         val=`echo $this_opt | sed -e s/^$arg://`
         case "$arg" in
-            client|server|clients|servers)
+            client|server|clients|servers|profiler)
                 addto_clients_servers "$arg" "$val"
                 ;;
             osruntime)
@@ -355,7 +355,7 @@ function launch_osruntime() {
 
     # For each client and server launch the actual script which will run it.
     count=1
-    for this_cs_label in ${clients[@]} ${servers[@]}; do
+    for this_cs_label in ${clients[@]} ${servers[@]} ${collectors[@]}; do
         tmp_osruntime=${osruntime[default]}
         set +u
         if [ ! -z "${osruntime[$this_cs_label]}" ]; then

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -1667,6 +1667,7 @@ sub prepare_bench_tool_engines() {
     chmod 0755, "$client_server_roadblock_script";
 
     my @collectors = grep(/[^client|^server]/, keys %clients_servers);
+    my @all_collector_types = qw(client server worker master profiler);
 
     # Each tool may specify, for specific endpoints, that it needs to run somewhere other than a client
     # or server (a "collector").  This preference is in the "whitelist" section.  Check each tool used
@@ -1692,7 +1693,7 @@ sub prepare_bench_tool_engines() {
         }
     }
     # Now build all of the tool start and stop cmd files for each collector
-    for my $collector (@collectors) {
+    for my $collector (@all_collector_typess) {
         for my $start_stop ("start", "stop") {
             my $collector_tool_cmds_dir = $tool_cmds_dir . "/" . $collector;
             -e $collector_tool_cmds_dir || make_path($collector_tool_cmds_dir) ||
@@ -1716,9 +1717,6 @@ sub prepare_bench_tool_engines() {
                     }
                 }
             }
-            #if ($tool_count == 0) {
-                #printf $fh "# this tool file is empty because there are no tools to run\n";
-            #}
             close($fh);
             chmod 0755, $tool_cmd_file;
         }
@@ -1809,9 +1807,7 @@ sub prepare_bench_tool_engines() {
     # These are files the client/server must copy from the controller before running any tests.
     # The "client-server-script" will first scp the list (client-files-list or server-files-list).
     # then it will read this list to know what other files to copy over)
-    #
-    # TODO: build these files for other collectors
-    foreach my $cs_type (keys %clients_servers, @collectors) {
+    foreach my $cs_type (keys %clients_servers, @all_collector_types) {
         my $cs_file_list = $client_server_config_dir . "/" . $cs_type . "-files-list";
         open(FH, ">" . $cs_file_list) || die "[ERROR]could not open " . $cs_file_list . " for writing";
         if ($cs_type =~ /(client|server)/ and exists $bench_config{$cs_type}{"files-from-controller"}) {
@@ -1851,7 +1847,7 @@ sub prepare_bench_tool_engines() {
         close FH;
     }
     # Create empty files for any not created above
-    foreach my $cs_type ("client", "server", "worker") {
+    foreach my $cs_type (keys %clients_servers, @all_collector_types) {
         my $cs_file_list = $client_server_config_dir . "/" . $cs_type . "-files-list";
         if ( ! -e $cs_file_list) {
             open(FH, ">" . $cs_file_list) || die "[ERROR]could not open " . $cs_file_list . " for writing";

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -1693,7 +1693,7 @@ sub prepare_bench_tool_engines() {
         }
     }
     # Now build all of the tool start and stop cmd files for each collector
-    for my $collector (@all_collector_typess) {
+    for my $collector (@all_collector_types) {
         for my $start_stop ("start", "stop") {
             my $collector_tool_cmds_dir = $tool_cmds_dir . "/" . $collector;
             -e $collector_tool_cmds_dir || make_path($collector_tool_cmds_dir) ||

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -1438,6 +1438,7 @@ sub validate_endpoints() {
     # and not rickshaw.
     my $min_id;
     my $max_id;
+    my $collectors_present = 0;
     printf "Confirming the endpoints will satisfy the benchmark-client ";
     printf "and benchmark-server " if exists $bench_config{'server'};
     printf "requirements\n";
@@ -1460,7 +1461,7 @@ sub validate_endpoints() {
         # server <int> [int]
         foreach my $line (@output) {
             chomp $line;
-            if ($line =~ /(client|server)\s+(.+)$/) {
+            if ($line =~ /(client|server|profiler)\s+(.+)$/) {
                 my $client_server = $1;
                 my $ids = $2;
                 foreach my $id (split(/\s+/, $ids)) {
@@ -1468,8 +1469,13 @@ sub validate_endpoints() {
                     my %info = ( 'endpoint-type' => $$endpoint{'type'}, 'id' => $id );
                     $clients_servers{$client_server}[$id - 1] = \%info;
                     push(@rb_cs_ids, $client_server . "-" . $id);
-                    $min_id = $id if (! defined $min_id or $id < $min_id);
-                    $max_id = $id if (! defined $max_id or $id > $max_id);
+                    if ($client_server =~ /(client|server)/) {
+                        $min_id = $id if (! defined $min_id or $id < $min_id);
+                        $max_id = $id if (! defined $max_id or $id > $max_id);
+                    }
+                    if ($client_server =~ /(collector)/) {
+                        $collectors_present++;
+                    }
                 }
             } elsif ($line =~ /(userenv)\s+(.+)$/) {
                 $$endpoint{'userenv'} = $2;
@@ -1536,6 +1542,7 @@ sub validate_endpoints() {
     }
     printf "There will be %d client(s)", $clients_present;
     printf " and %d server(s)", $servers_present if exists $bench_config{'server'} && $servers_present;
+    printf " and %d collector(s)", $collectors_present if $collectors_present;
     printf "\n";
     $endpoint_roadblock_opt = " --roadblock-id=" . $run{'id'} .
         " --roadblock-passwd=" . $redis_passwd;
@@ -1658,10 +1665,13 @@ sub prepare_bench_tool_engines() {
     copy($run{'roadblock-dir'} . "/roadblock.py", $client_server_roadblock_script)
         || die "Could not copy roadblock.py to " . $client_server_roadblock_script;
     chmod 0755, "$client_server_roadblock_script";
+
+    my @collectors = grep(/[^client|^server]/, keys %clients_servers);
+
     # Each tool may specify, for specific endpoints, that it needs to run somewhere other than a client
     # or server (a "collector").  This preference is in the "whitelist" section.  Check each tool used
     # to see if we need to build a command file for any of these collectors.
-    my %collectors;
+    my %collector_tools;
     foreach my $tool_entry (@tools_params) {
         my $tool_name = $$tool_entry{'tool'};
         if (exists $tools_configs{$tool_name}{'collector'}{'whitelist'}) {
@@ -1671,28 +1681,44 @@ sub prepare_bench_tool_engines() {
                 if (grep(/^$endpoint$/, dump_endpoint_types(\@endpoints))) {
                     # Then add this tool to the list of tools for this collector
                     for my $collector (@{ $$i{'collector-types'} }) {
-                        if (! exists($collectors{$collector})) {
-                            $collectors{$collector} = ();
+                        if (! exists($collector_tools{$collector})) {
+                            $collector_tools{$collector} = ();
                         }
-                        push(@{ $collectors{$collector} }, $tool_name);
+                        debug_log("Adding " . $tool_name . " to " . $collector . "\n");
+                        push(@{ $collector_tools{$collector} }, $tool_name);
                     }
                 }
             }
         }
     }
     # Now build all of the tool start and stop cmd files for each collector
-    for my $collector (keys %collectors) {
+    for my $collector (@collectors) {
         for my $start_stop ("start", "stop") {
             my $collector_tool_cmds_dir = $tool_cmds_dir . "/" . $collector;
             -e $collector_tool_cmds_dir || make_path($collector_tool_cmds_dir) ||
                 die "[ERROR]Create collector directory failed: [" . $collector_tool_cmds_dir . "]\n";
             my $tool_cmd_file = $collector_tool_cmds_dir . "/" . $start_stop; 
+            my $tool_count = 0;
             open(my $fh, ">" . $tool_cmd_file) ||
                 die "[ERROR]could not open cmd file for writing: [" . $tool_cmd_file . "]\n";
             debug_log(sprintf "writing tool-cmds [%s]\n", $tool_cmd_file);
             foreach my $tool_entry (@tools_params) {
-                build_tool_cmd($tool_entry, $start_stop, $fh);
+                my $tool_name = $$tool_entry{'tool'};
+                debug_log(sprintf "tool_name: [%s]\n", $tool_name);
+                for my $i (@{ $tools_configs{$tool_name}{'collector'}{'whitelist'} }) {
+                    debug_log(sprintf "endpoint: [%s]\n", $$i{'endpoint'});
+                    if (grep(/^$collector$/, @{ $$i{'collector-types'} })) {
+                        debug_log(sprintf "building tool cmd for [%s]\n", $tool_name);
+                        build_tool_cmd($tool_entry, $start_stop, $fh);
+                        $tool_count++;
+                    } else {
+                        debug_log(sprintf "collector [%s] was not found in collector-types: [%s]\n", $collector, join(" ", @{ $$i{'collector-types'} }));
+                    }
+                }
             }
+            #if ($tool_count == 0) {
+                #printf $fh "# this tool file is empty because there are no tools to run\n";
+            #}
             close($fh);
             chmod 0755, $tool_cmd_file;
         }
@@ -1704,6 +1730,7 @@ sub prepare_bench_tool_engines() {
     # and/or server would be collecting duplicate data).  For this reason tool
     # cmd files are built specifically for each client and server.
     foreach my $cs_type (keys %clients_servers) {
+        next if ($cs_type eq "profiler"); # Currently we do not generate specific tools cmds for each profiler
         for my $start_stop ("start", "stop") {
             foreach my $cs_ref (@{ $clients_servers{$cs_type} }) {
                 my $cs_tool_cmds_dir = $tool_cmds_dir . "/" . $cs_type . "/" . $$cs_ref{'id'};
@@ -1711,6 +1738,7 @@ sub prepare_bench_tool_engines() {
                 my $tool_cmd_file = $cs_tool_cmds_dir . "/" . $start_stop;
                 open(my $fh, ">" . $tool_cmd_file) ||
                     die "[ERROR]could not open cmd file for writing: [" . $tool_cmd_file . "]\n";
+                debug_log(sprintf "writing tool-cmds [%s]\n", $tool_cmd_file);
                 foreach my $tool_entry (@tools_params) {
                     build_tool_cmd($tool_entry, $start_stop, $fh, $$cs_ref{'endpoint-type'});
                 }
@@ -1721,7 +1749,9 @@ sub prepare_bench_tool_engines() {
     }
     # Build the client and server bench-cmd files
     # Each benchmark has to define the commands used in their rickshaw.json
+    debug_log(sprintf "clients_servers: [%s]\n", join(" ", keys %clients_servers));
     foreach my $cs_type (keys %clients_servers) {
+        next if ($cs_type eq "profiler"); # This does not use bench-cmds
         foreach my $cs_ref (@{ $clients_servers{$cs_type} }) {
             my @cmd_type_files = ("start");
             if ($cs_type eq "server") {
@@ -1781,7 +1811,7 @@ sub prepare_bench_tool_engines() {
     # then it will read this list to know what other files to copy over)
     #
     # TODO: build these files for other collectors
-    foreach my $cs_type (keys %clients_servers, keys %collectors) {
+    foreach my $cs_type (keys %clients_servers, @collectors) {
         my $cs_file_list = $client_server_config_dir . "/" . $cs_type . "-files-list";
         open(FH, ">" . $cs_file_list) || die "[ERROR]could not open " . $cs_file_list . " for writing";
         if ($cs_type =~ /(client|server)/ and exists $bench_config{$cs_type}{"files-from-controller"}) {

--- a/schema/tool.json
+++ b/schema/tool.json
@@ -48,7 +48,7 @@
               "endpoint": {
                 "type": "string",
                 "enum": [
-                  "local",
+                  "remotehost",
                   "k8s"
                 ]
               }
@@ -64,7 +64,7 @@
               "endpoint": {
                 "type": "string",
                 "enum": [
-                  "local",
+                  "remotehost",
                   "k8s"
                 ]
               }


### PR DESCRIPTION
- User can collect tools without a client or server when using
  --endpoint remotehost,profiler:<n>. where n is a unique profiler
  number (ideally start with "1")

- A "profiler" is a type of collector, much like we have a worker
  and master collector for k8s endpoint

- All of the tools need to add entries for "remotehost" in their
  whitelist section, in order for that tool to be used by the profiler,
  just like is done for tools for master and worker collector