### PR TITLE
Support adding benchmark name to bench-metric

### DIFF
--- a/schema/bench-metric.json
+++ b/schema/bench-metric.json
@@ -23,6 +23,9 @@
       ],
       "additionalProperties": false
     },
+    "benchmark": {
+      "type": "string"
+    },
     "primary-metric": {
       "type": "string"
     },


### PR DESCRIPTION
-this schema is used for post-process-data.json
-when rickshaw supports just 1 benchmark type per run,
 the benchmark name was generally already known,
 as post-processing was done for a known, singular
 benchmark.  To prepare to multi-benchmark use, we
 need the post-process-data to include the benchmark
 name.  Once this is merged, all benchmark subprojects
 will need to be updated to include their benchmark
 name in this file they generate.