### PR TITLE
when calculating image tags ignore files not relevant to runtime exec…

### DIFF
--- a/rickshaw-run
+++ b/rickshaw-run
@@ -152,7 +152,10 @@ sub find_files {
 
             if (($entry =~ /^\.$/) ||
                 ($entry =~ /^\.\.$/) ||
-                ($entry =~ /^\.git$/)) {
+                ($entry =~ /^\.git$/) ||
+                ($entry =~ /^docs$/) ||
+                ($entry =~ /\.md$/) ||
+                ($entry =~ /^\.github$/)) {
                 next;
             }
 


### PR DESCRIPTION
…ution

- ignore the following files/directories which do not affect actual runtime execution (there is no reason to rebuild the images due to changes only to these files)

  - anything in a <repo>/docs directory

  - all markdown files (ie. README.md)

  - github related files (ie. actions and/or workflows)