### PR TITLE
Add stream8-flexran userenv

### DIFF
--- a/userenvs/stream8-flexran.json
+++ b/userenvs/stream8-flexran.json
@@ -1,0 +1,94 @@
+{
+  "workshop": {
+    "schema": {
+      "version": "2022.07.25"
+    }
+  },
+  "userenv": {
+    "name": "stream8-flexran",
+    "label": "flexRAN Stream 8",
+    "origin": {
+      "image": "quay.io/xxx/yyy",
+      "tag": "zzz"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "dnf"
+      }
+    }
+  },
+  "requirements": [
+    {
+      "name": "python39",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "python39",
+          "python39-pip"
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "curl",
+          "tar",
+          "cpio",
+          "gzip",
+          "jq",
+          "git",
+          "cpio",
+          "findutils",
+          "hostname",
+          "iputils",
+          "iproute",
+          "elfutils-libelf",
+          "elfutils-libelf-devel",
+          "openssl",
+          "openssl-devel",
+          "xz",
+          "xz-devel",
+          "libcap",
+          "libzstd",
+          "libzstd-devel",
+          "libcap-devel"
+        ]
+      }
+    },
+    {
+      "name": "core-compiling",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "diffutils",
+          "gcc",
+          "libtool",
+          "autoconf",
+          "automake",
+          "make"
+        ]
+      }
+    },
+    {
+      "name": "core-perl",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "perl-App-cpanminus"
+        ]
+      }
+    },
+    {
+      "name": "core-node",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "nodejs"
+        ]
+      }
+    }
+  ]
+}

--- a/userenvs/stream8-flexran/requirements/02-python.json
+++ b/userenvs/stream8-flexran/requirements/02-python.json
@@ -1,0 +1,1 @@
+../../components/rpm-python39.json

--- a/userenvs/stream8-flexran/requirements/03-core-utils.json
+++ b/userenvs/stream8-flexran/requirements/03-core-utils.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-utils.json

--- a/userenvs/stream8-flexran/requirements/04-core-compiling.json
+++ b/userenvs/stream8-flexran/requirements/04-core-compiling.json
@@ -1,0 +1,1 @@
+../../components/rpm-core-compiling.json

--- a/userenvs/stream8-flexran/requirements/05-core-perl.json
+++ b/userenvs/stream8-flexran/requirements/05-core-perl.json
@@ -1,0 +1,1 @@
+../../components/core-perl.json

--- a/userenvs/stream8-flexran/requirements/06-core-node.json
+++ b/userenvs/stream8-flexran/requirements/06-core-node.json
@@ -1,0 +1,1 @@
+../../components/core-node.json

--- a/userenvs/stream8-flexran/schema.json
+++ b/userenvs/stream8-flexran/schema.json
@@ -1,0 +1,1 @@
+../components/schema.json

--- a/userenvs/stream8-flexran/userenv.json
+++ b/userenvs/stream8-flexran/userenv.json
@@ -1,0 +1,14 @@
+  "userenv": {
+    "name": "stream8-flexran",
+    "label": "flexRAN Stream 8",
+    "origin": {
+      "image": "quay.io/xxx/yyy",
+      "tag": "zzz"
+    },
+    "properties": {
+      "packages": {
+        "type": "rpm",
+        "manager": "dnf"
+      }
+    }
+  },


### PR DESCRIPTION
Beginning from FlexRAN v22.03 going forward, we build the flexran client-server image on top of a stream8-flexran based image.  The instruction to build the based image is [here](https://docs.google.com/document/d/1sKJzcm0oiui5C6e6QzHLFMAX8HAzAnUmQwD7-kAcpcM/edit#heading=h.bs1eewbj7n2w).

Prior to this, the engines have to mount the host filesystem that contains the BIG flexran blob (100MB).