### PR TITLE
change controller ping behavior

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -568,7 +568,7 @@ function do_roadblock() {
     local msgs_log_file="$roadblock_msgs_dir/$label.json"
     local cmd=""
     local role="follower"
-    ping -w 10 -c 4 localhost || exit_error "Could not ping controller 4 times in 10 seconds"
+    ping -w 10 -c 4 localhost
     cmd="${cmd} /usr/local/bin/roadblock.py --role=${role} --redis-server=localhost"
     cmd="${cmd} --leader-id=${leader} --timeout=${timeout} --redis-password=${rb_passwd}"
     cmd="${cmd} --follower-id=${endpoint_label} --message-log=${msgs_log_file}"

--- a/engine/engine-script-library
+++ b/engine/engine-script-library
@@ -82,7 +82,7 @@ function do_roadblock() {
     local msgs_log_file="$roadblock_msgs_dir/$label.json"
     local cmd=""
     local role="follower"
-    ping -c 4 $rickshaw_host || exit_error "Could not ping controller"
+    ping -w 10 -c 4 ${rickshaw_host}
     cmd="$cmd $roadblock_bin --role=${role} --redis-server=$rickshaw_host"
     cmd="$cmd --leader-id=$leader --timeout=$timeout --redis-password=$roadblock_passwd"
     cmd="$cmd --follower-id=$cs_label --message-log=$msgs_log_file"


### PR DESCRIPTION
- use ping deadline

- do not treat a ping failure as an error state

  - the ping is simply for informational purposes in debugging situations

  - roadblock should have sufficient retry and logging to properly handle network connectivity problems -- if that is not true it is a roadblock bug that should be fixed there, not by the caller