### PR TITLE
temporarily bypass the "real CI" for the engine python port work

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -8,6 +8,8 @@ on:
     - '**.md'
     - .github/workflows/faux-crucible-ci.yaml
     - 'docs/**'
+    - engine/engine-script-library.py
+    - engine/engine-script.py
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/faux-crucible-ci.yaml
+++ b/.github/workflows/faux-crucible-ci.yaml
@@ -8,6 +8,8 @@ on:
     - '**.md'
     - .github/workflows/faux-crucible-ci.yaml
     - 'docs/**'
+    - engine/engine-script-library.py
+    - engine/engine-script.py
 
 jobs:
   call-core-crucible-ci:

--- a/.github/workflows/faux-unittest.yaml
+++ b/.github/workflows/faux-unittest.yaml
@@ -9,6 +9,8 @@ on:
       - .github/workflows/faux-unittest.yaml
       - .github/workflows/faux-crucible-ci.yaml
       - 'docs/**'
+      - engine/engine-script-library.py
+      - engine/engine-script.py
 
 jobs:
   unittest-complete:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -9,6 +9,8 @@ on:
       - .github/workflows/faux-unittest.yaml
       - .github/workflows/faux-crucible-ci.yaml
       - 'docs/**'
+      - engine/engine-script-library.py
+      - engine/engine-script.py
 
   workflow_dispatch:
 


### PR DESCRIPTION
- use the faux CI for now