### PR TITLE
Add multibench support to all-in-one json

### DIFF
--- a/util/JSON/schema.json
+++ b/util/JSON/schema.json
@@ -10,7 +10,8 @@
                     "enum": [
                         "2022.11.08",
                         "2023.03.10",
-                        "2023.06.06"
+                        "2023.06.06",
+                        "2023.09.12"
                     ]
                 }
             }
@@ -76,18 +77,30 @@
                                 }
                             }
                         ]
+                    },
+                    "mv-params": {
+                        "anyOf": [
+                            {
+                                "type": "array",
+                                "items": {
+                                    "minItems": 1,
+                                    "type": "object"
+                                }
+                            },
+                            {
+                                "type": "object"
+                            }
+                        ]
                     }
                 },
                 "additionalProperties": false,
                 "required": [
                     "name",
-                    "ids"
+                    "ids",
+                    "mv-params"
                 ]
             }
         }
     },
-    "additionalProperties": false,
-    "required": [
-        "mv-params"
-    ]
+    "additionalProperties": false
 }

--- a/util/tests/JSON/input-multibench-k8s-remotehost.json
+++ b/util/tests/JSON/input-multibench-k8s-remotehost.json
@@ -1,55 +1,63 @@
 {
     "benchmarks": [
-        { "name": "oslat", "ids": "1-2" },
-        { "name": "uperf", "ids": ["3-4","6-7"] },
-        { "name": "iperf", "ids": "5" }
-    ],
-    "mv-params": [
         {
-            "sets": [
-                {
-                    "params": [
-                        { "arg": "duration", "vals": [ "10" ], "role": "client" },
-                        { "arg": "rtprio", "vals": [ "1" ], "role": "client" }
-                    ]
-                }
-            ]
+            "name": "oslat",
+            "ids": "1-2",
+            "mv-params": {
+                "sets": [
+                    {
+                        "params": [
+                            { "arg": "duration", "vals": [ "10" ], "role": "client" },
+                            { "arg": "rtprio", "vals": [ "1" ], "role": "client" }
+                        ]
+                    }
+                ]
+            }
         },
         {
-            "sets": [
-                {
-                    "params": [
-                        { "arg": "ifname", "vals": ["eth0"], "role": "server" },
-                        { "arg": "ipv", "vals": ["6"], "role": "all" },
-                        { "arg": "protocol", "vals": ["udp"], "id": "21" },
-                        { "arg": "bitrate", "vals": ["200M"], "id": "21" },
-                        { "arg": "length", "vals": ["256"], "id": "21" }
-                    ]
-                }
-            ]
+            "name": "uperf",
+            "ids": ["3-4","6-7"],
+            "mv-params": {
+                "sets": [
+                    {
+                        "params": [
+                            { "arg": "ifname", "vals": ["eth0"], "role": "server" },
+                            { "arg": "ipv", "vals": ["6"], "role": "all" },
+                            { "arg": "protocol", "vals": ["udp"], "id": "21" },
+                            { "arg": "bitrate", "vals": ["200M"], "id": "21" },
+                            { "arg": "length", "vals": ["256"], "id": "21" }
+                        ]
+                    }
+                ]
+
+            }
         },
         {
-            "global-options": [
-                {
-                    "name": "common-params",
-                    "params": [
-                        { "arg": "duration", "vals": ["60"] },
-                        { "arg": "protocol", "vals": ["tcp"] },
-                        { "arg": "nthreads", "vals": ["1"] },
-                        { "arg": "ifname", "vals": ["eth0"], "role": "server" }
-                    ]
-                }
-            ],
-            "sets": [
-                {
-                    "include": "common-params",
-                    "params": [
-                        { "arg": "test-type", "vals": ["crr"], "id": "1" },
-                        { "arg": "wsize", "vals": ["512"], "id": "1" },
-                        { "arg": "rsize", "vals": ["2048"], "id": "1" }
-                    ]
-                }
-            ]
+            "name": "iperf",
+            "ids": "5",
+            "mv-params": {
+                "global-options": [
+                    {
+                        "name": "common-params",
+                        "params": [
+                            { "arg": "duration", "vals": ["60"] },
+                            { "arg": "protocol", "vals": ["tcp"] },
+                            { "arg": "nthreads", "vals": ["1"] },
+                            { "arg": "ifname", "vals": ["eth0"], "role": "server" }
+                        ]
+                    }
+                ],
+                "sets": [
+                    {
+                        "include": "common-params",
+                        "params": [
+                            { "arg": "test-type", "vals": ["crr"], "id": "1" },
+                            { "arg": "wsize", "vals": ["512"], "id": "1" },
+                            { "arg": "rsize", "vals": ["2048"], "id": "1" }
+                        ]
+                    }
+                ]
+            }
         }
     ],
     "tool-params": [

--- a/util/tests/test-blockbreaker.py
+++ b/util/tests/test-blockbreaker.py
@@ -169,11 +169,11 @@ class TestBlockBreaker:
         expected_output = self._load_file("output-oslat-k8s-mvparams.json")
         assert input_json == expected_output
 
-    """Test if dump_json returns the correct json block from mv-params idx 1"""
+    """Test if dump_json returns the correct json block from mv-params for uperf"""
     @pytest.mark.parametrize("load_json_file",
                              [ "input-multibench-k8s-remotehost.json" ], indirect=True)
     def test_dump_json_mvparams_index1(self, load_json_file):
         assert type(load_json_file) == dict
-        input_json = blockbreaker.dump_json(load_json_file, "mv-params", 1)
+        input_json = blockbreaker.dump_json(load_json_file["benchmarks"][1], "mv-params", "uperf")
         expected_output = self._load_file("output-multibench-k8s-remotehost-mvparams1.json")
         assert input_json == expected_output


### PR DESCRIPTION
Add benchmarks block to identify bench ids.
The blockbreaker utility extracts the benchmark
from the runfile and processes multibench config.

This requires additional changes on the crucible
code to fully support 'benchmarks' block from the
json runfile.