### PR TITLE
Do not print warnings on stdout by default

### DIFF
--- a/util/tests/test-blockbreaker.py
+++ b/util/tests/test-blockbreaker.py
@@ -64,7 +64,7 @@ class TestBlockBreaker:
     def test_json_to_stream_endpoints_invalid_idx(self, load_json_file, capsys):
         input_json = blockbreaker.json_to_stream(load_json_file, "endpoints", 1)
         out, err = capsys.readouterr()
-        assert 'Invalid index' in out
+        assert out == ""
         assert input_json is None
 
     """Test validate_schema using default schema for null schema_file arg"""


### PR DESCRIPTION
Print warnings and non-critical errors on stderr
only if '--verbose' is used. Ignore warnings and
non-error messages if not critical, e.g. a block
that was requested that does not exist, or an
index from an endpoint array.