### PR TITLE
restrict github faux workflows to only running on files explicitly li…

### DIFF
--- a/.github/workflows/faux-crucible-ci.yaml
+++ b/.github/workflows/faux-crucible-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [ master ]
     paths:
+    - '!**'
     - LICENSE
     - '**.md'
     - .github/workflows/faux-unittest.yaml

--- a/.github/workflows/faux-unittest.yaml
+++ b/.github/workflows/faux-unittest.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [ master ]
     paths:
+      - '!**'
       - LICENSE
       - '**.md'
       - .github/workflows/faux-unittest.yaml


### PR DESCRIPTION
…sted in their paths list by ignoring all other files

- we only want the faux workflows to run when the explicitly listed files are modified AND only those files are modified

- we don't want the faux workflows to execute in parallel to the non faux workflows because then the branch protection rules will always be meet