### PR TITLE
switch egrep to 'grep -E'

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -1051,9 +1051,9 @@ function process_roadblocks() {
 function is_ip() {
     local ip=$1; shift
 
-    if echo "$ip" | egrep --silent '[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}'; then
+    if echo "$ip" | grep -E --silent '[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}'; then
         return 0
-    elif echo "$ip" | egrep --silent '[[:xdigit:]]{1,4}\:[[:xdigit:]]{1,4}\:[[:xdigit:]]{1,4}\:[[:xdigit:]]{1,4}\:[[:xdigit:]]{1,4}\:[[:xdigit:]]{1,4}\:[[:xdigit:]]{1,4}\:[[:xdigit:]]'; then
+    elif echo "$ip" | grep -E --silent '[[:xdigit:]]{1,4}\:[[:xdigit:]]{1,4}\:[[:xdigit:]]{1,4}\:[[:xdigit:]]{1,4}\:[[:xdigit:]]{1,4}\:[[:xdigit:]]{1,4}\:[[:xdigit:]]{1,4}\:[[:xdigit:]]'; then
         return 0
     else
         return 1


### PR DESCRIPTION
- newer versions of egrep emit messages about it being obsolete; this output can break us in some situations