### PR TITLE
check for non-empty string before delete svc

### DIFF
--- a/endpoints/k8s/k8s
+++ b/endpoints/k8s/k8s
@@ -127,7 +127,9 @@ function endpoint_k8s_test_stop() {
     services=`do_ssh $user@$host kubectl -n $project_name get svc | grep rickshaw | awk '{print $1}'`
     echo "Services to delete:"
     echo $services
-    do_ssh $user@$host kubectl -n $project_name delete svc $services
+    if [[ ! -z "$services" ]]; then
+       do_ssh $user@$host kubectl -n $project_name delete svc $services
+    fi
 }
 
 function endpoint_k8s_test_start() {


### PR DESCRIPTION
There are cases that we do not create a svc e.g. k8s endpoint that has "hostNetwork:1" flag.
So on the delete side, check for empty before invoke "delete svc".