### PR TITLE
increase the size of the remotehost image cache by 3x

### DIFF
--- a/endpoints/remotehost/remotehost
+++ b/endpoints/remotehost/remotehost
@@ -43,7 +43,7 @@ fi
 # globals (also check $endpoint_base_dir/base for others!!!)
 chroot_rbind_mounts="proc dev sys lib/firmware lib/modules usr/src boot var/run"
 endpoint_name="remotehost"
-image_cache_size=3
+image_cache_size=9
 declare -A osruntime
 osruntime[default]="chroot"
 host_mounts=""


### PR DESCRIPTION
- origingally, when the cache was size 3 that was literally enough images for 3 separate runs since each image was used for all aspects of the run

- with the change to one-tool it can take 3 images just for a basic run (one benchmark and two tools -- procstat and systat) so the image requirements have gone up

- in order to maintain a similar level of cache locality from a run perspective it needs to be increased, so take the basic run config and scale based on it