### PR TITLE
Add  "user-project" option to accept a user-defined project name

### DIFF
--- a/endpoints/k8s/k8s
+++ b/endpoints/k8s/k8s
@@ -56,6 +56,7 @@ pod_prefix="rickshaw"
 project_name="crucible-rickshaw"
 hypervisor_host="none"
 unique_project="0"
+user_project=""
 hostNetwork="0"
 hugepage="0"
 osruntime[default]="pod"
@@ -421,7 +422,13 @@ function process_k8s_opts() {
         val=`echo $opt | sed -e s/^$arg://`
         case "$arg" in
             unique-project)
+                # This option auto-generates a project name. CLI option '--unique-project=1'
                 unique_project=${val}
+                ;;
+            user-project)
+                # This option allows a user-defined project name. CLI option '--user-project=my-k8s-project'
+                # unique-project option has higher precedence.
+                user_project=${val}
                 ;;
             kubeconfig)
                 kubeconfig=$val
@@ -517,6 +524,8 @@ function process_k8s_opts() {
 
     if [ "${unique_project}" == "1" ]; then
         project_name+="--${run_id}-${endpoint_label}"
+    elif [ ! -z "${user_project}" ]; then
+        project_name="${user_project}"
     fi
 }
 

--- a/endpoints/k8s/k8s
+++ b/endpoints/k8s/k8s
@@ -56,7 +56,6 @@ pod_prefix="rickshaw"
 project_name="crucible-rickshaw"
 hypervisor_host="none"
 unique_project="0"
-user_project=""
 hostNetwork="0"
 hugepage="0"
 osruntime[default]="pod"
@@ -425,11 +424,6 @@ function process_k8s_opts() {
                 # This option auto-generates a project name. CLI option '--unique-project=1'
                 unique_project=${val}
                 ;;
-            user-project)
-                # This option allows a user-defined project name. CLI option '--user-project=my-k8s-project'
-                # unique-project option has higher precedence.
-                user_project=${val}
-                ;;
             kubeconfig)
                 kubeconfig=$val
                 ;;
@@ -524,8 +518,8 @@ function process_k8s_opts() {
 
     if [ "${unique_project}" == "1" ]; then
         project_name+="--${run_id}-${endpoint_label}"
-    elif [ ! -z "${user_project}" ]; then
-        project_name="${user_project}"
+    elif [ ! -z "${unique_project}" ]  &&  [ "${unique_project}" != "0" ]; then
+        project_name="${unique_project}"
     fi
 }
 

--- a/endpoints/k8s/k8s
+++ b/endpoints/k8s/k8s
@@ -421,7 +421,7 @@ function process_k8s_opts() {
         val=`echo $opt | sed -e s/^$arg://`
         case "$arg" in
             unique-project)
-                # This option auto-generates a project name. CLI option '--unique-project=1'
+                # val="1" auto-generates a project name. val="other_string", use string as project name.
                 unique_project=${val}
                 ;;
             kubeconfig)


### PR DESCRIPTION
Synopsis:

Add another flavor of setting run project.  Currently crucible-rickshaw is the default project. There is also the "unique-project" option which autogenerates a project name with UUID. This new "user-project" option allows the user to specify a user-defined project name. 

Unit test:
1. Default project name crucible-rickshaw works correctly when no unique-project or user-project option.
2. unique-project option works correctly
3. user-project works correctly