### PR TITLE
modify bootstrap to log the CPUs allowed list when cpu-partitioning i…

### DIFF
--- a/engine/bootstrap
+++ b/engine/bootstrap
@@ -268,6 +268,9 @@ if [ "${cpu_partitioning}" == "1" ]; then
     taskset --cpu-list --pid ${HK_CPUS} $$
 else
     echo "Disabled"
+    echo
+    echo "Since cpu-partitioning is disabled, logging the allowed runnable CPUs here for informational purposes:"
+    grep Cpus_allowed_list /proc/self/status
 fi
 echo
 


### PR DESCRIPTION
…s not in use

- this may be helpful to understand the limitations that may (or may not) be being imposed by other components of the test infrastructure (ie. NUMA binding, K8S guaranteed pods, etc.)