### PR TITLE
update remotehosts.py to formally name the threads it launches

### DIFF
--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -1288,10 +1288,10 @@ def image_pull_worker_thread(thread_id, work_queue, threads_rcs):
             remote = work_queue.get(block = False)
         except queue.Empty:
             thread_logger(thread_name, "Received a work queue empty exception")
-            continue
+            break
 
         if remote is None:
-            thread_logger(thread_name, "Received a null job")
+            thread_logger(thread_name, "Received a null job", log_level = "warning")
             continue
 
         job_count += 1
@@ -1513,10 +1513,10 @@ def remote_mkdirs_worker_thread(thread_id, work_queue, threads_rcs):
             remote = work_queue.get(block = False)
         except queue.Empty:
             thread_logger(thread_name, "Received a work queue empty exception")
-            continue
+            break
 
         if remote is None:
-            thread_logger(thread_name, "Received a null job")
+            thread_logger(thread_name, "Received a null job", log_level = "warning")
             continue
 
         job_count += 1
@@ -1966,10 +1966,11 @@ def launch_engines_worker_thread(thread_id, work_queue, threads_rcs):
             remote_idx = work_queue.get(block = False)
         except queue.Empty:
             thread_logger(thread_name, "Received a work queue empty exception")
-            continue
+            break
 
         if remote_idx is None:
-            thread_logger(thread_name, "Received a null job")
+            thread_logger(thread_name, "Received a null job", log_level = "warning")
+            continue
 
         job_count += 1
 
@@ -3310,10 +3311,11 @@ def shutdown_engines_worker_thread(thread_id, work_queue, threads_rcs):
             remote_idx = work_queue.get(block = False)
         except queue.Empty:
             thread_logger(thread_name, "Received a work queue empty exception")
-            continue
+            break
 
         if remote_idx is None:
-            thread_logger(thread_name, "Received a null job")
+            thread_logger(thread_name, "Received a null job", log_level = "warning")
+            continue
 
         job_count += 1
 
@@ -3425,10 +3427,11 @@ def image_mgmt_worker_thread(thread_id, work_queue, threads_rcs):
             remote = work_queue.get(block = False)
         except queue.Empty:
             thread_logger(thread_name, "Received a work queue empty exception")
-            continue
+            break
 
         if remote is None:
-            thread_logger(thread_name, "Received a null job")
+            thread_logger(thread_name, "Received a null job", log_level = "warning")
+            continue
 
         job_count += 1
 
@@ -3517,10 +3520,11 @@ def collect_sysinfo_worker_thread(thread_id, work_queue, threads_rcs):
             remote = work_queue.get(block = False)
         except queue.Empty:
             thread_logger(thread_name, "Received a work queue empty exception")
-            continue
+            break
 
         if remote is None:
-            thread_logger(thread_name, "Received a null job")
+            thread_logger(thread_name, "Received a null job", log_level = "warning")
+            continue
 
         job_count += 1
 

--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -101,7 +101,7 @@ def remote_connection(host, user):
                     validate_comment(msg)
                 else:
                     log.info(msg)
-                break
+            break
         except (ssh_exception.AuthenticationException, ssh_exception.NoValidConnectionsError) as e:
             msg = "Failed to connect to remote '%s' as user '%s' on attempt %d due to '%s'" % (host, user, attempt, str(e))
             if args.validate:

--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -1276,7 +1276,8 @@ def image_pull_worker_thread(thread_id, work_queue, threads_rcs):
     Returns:
         None
     """
-    thread_name = "IPWT-%d" % (thread_id)
+    thread = threading.current_thread()
+    thread_name = thread.name
     thread_logger(thread_name, "Starting image pull thread with thread ID %d and name = '%s'" % (thread_id, thread_name))
     rc = 0
     job_count = 0
@@ -1427,7 +1428,7 @@ def create_thread_pool(description, acronym, work, worker_threads_count, worker_
             thread_logger("MAIN", "Aborting %s launch because no more work to do" % (acronym))
             break
         thread_logger("MAIN", "Creating and starting %s with thread ID %d" % (acronym, thread_id))
-        worker_threads[thread_id] = threading.Thread(target = worker_thread_function, args = (thread_id, work, worker_threads_rcs))
+        worker_threads[thread_id] = threading.Thread(target = worker_thread_function, args = (thread_id, work, worker_threads_rcs), name = "%s-%d" % (acronym, thread_id))
         worker_threads[thread_id].start()
 
     thread_logger("MAIN", "Waiting for all %s work jobs to be consumed" % (acronym))
@@ -1500,7 +1501,8 @@ def remote_mkdirs_worker_thread(thread_id, work_queue, threads_rcs):
     Returns:
         None
     """
-    thread_name = "RWMT-%d" % (thread_id)
+    thread = threading.current_thread()
+    thread_name = thread.name
     thread_logger(thread_name, "Starting remote mkdirs thread with thread ID %d and name = '%s'" % (thread_id, thread_name))
     rc = 0
     job_count = 0
@@ -1952,7 +1954,8 @@ def launch_engines_worker_thread(thread_id, work_queue, threads_rcs):
     Returns:
         None
     """
-    thread_name = "LEWT-%d" % (thread_id)
+    thread = threading.current_thread()
+    thread_name = thread.name
     thread_logger(thread_name, "Starting launch engines thread with thread ID %d and name = '%s'" % (thread_id, thread_name))
     rc = 0
     job_count = 0
@@ -3295,7 +3298,8 @@ def shutdown_engines_worker_thread(thread_id, work_queue, threads_rcs):
     Returns:
         None
     """
-    thread_name = "SEWT-%d" % (thread_id)
+    thread = threading.current_thread()
+    thread_name = thread.name
     thread_logger(thread_name, "Starting shutdown engines thread with thread ID %d and name = '%s'" % (thread_id, thread_name))
     rc = 0
     job_count = 0
@@ -3409,7 +3413,8 @@ def image_mgmt_worker_thread(thread_id, work_queue, threads_rcs):
     Returns:
         None
     """
-    thread_name = "IMWT-%d" % (thread_id)
+    thread = threading.current_thread()
+    thread_name = thread.name
     thread_logger(thread_name, "Starting image management thread with thread ID %d and name = '%s'" % (thread_id, thread_name))
     rc = 0
     job_count = 0
@@ -3500,7 +3505,8 @@ def collect_sysinfo_worker_thread(thread_id, work_queue, threads_rcs):
     Returns:
         None
     """
-    thread_name = "CSWT-%d" % (thread_id)
+    thread = threading.current_thread()
+    thread_name = thread.name
     thread_logger(thread_name, "Starting collect sysinfo thread with thread ID %d and name = '%s'" % (thread_id, thread_name))
     rc = 0
     job_count = 0

--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -21,6 +21,7 @@ import sys
 import tempfile
 import threading
 import time
+import traceback
 
 TOOLBOX_HOME = os.environ.get('TOOLBOX_HOME')
 if TOOLBOX_HOME is None:
@@ -3721,6 +3722,28 @@ def setup_logger():
 
     return logging.getLogger(__file__)
 
+def thread_exception_hook(args):
+    """
+    Generic thread exception handler
+
+    Args:
+        args (namespace): information about the exception being handled
+
+    Globals:
+        log: a logger instance
+
+    Returns:
+        None
+    """
+    thread_name = "UNKNOWN"
+    if not args.thread is None:
+        thread_name = args.thread.name
+
+    msg = "[Thread %s] Thread failed with exception:\ntype: %s\nvalue: %s\ntraceback:\n%s" % (thread_name, args.exc_type, args.exc_value, "".join(traceback.format_list(traceback.extract_tb(args.exc_traceback))))
+    log.error(msg, stacklevel = 3)
+
+    return
+
 def main():
     """
     Main control block
@@ -3737,6 +3760,8 @@ def main():
     global args
     global log
     global settings
+
+    threading.excepthook = thread_exception_hook
 
     if args.validate:
         return(validate())


### PR DESCRIPTION
- this is helpful because if Python throws an error message it will include the formal name of the thread which can be useful for tracking where the problem came from