### PR TITLE
drop rtprio for bench-oslat

### DIFF
--- a/util/crucible-ci/oslat.k8s.json
+++ b/util/crucible-ci/oslat.k8s.json
@@ -8,8 +8,7 @@
                     {
                         "name": "common-params",
                         "params": [
-                            { "arg": "duration", "vals": [ "10" ], "role": "client" },
-                            { "arg": "rtprio", "vals": [ "1", "2" ], "role": "client" }
+                            { "arg": "duration", "vals": [ "10", "15" ], "role": "client" }
                         ]
                     }
                 ],

--- a/util/crucible-ci/oslat.remotehost.json
+++ b/util/crucible-ci/oslat.remotehost.json
@@ -8,8 +8,7 @@
                     {
                         "name": "common-params",
                         "params": [
-                            { "arg": "duration", "vals": [ "10" ], "role": "client" },
-                            { "arg": "rtprio", "vals": [ "1", "2" ], "role": "client" }
+                            { "arg": "duration", "vals": [ "10", "15" ], "role": "client" }
                         ]
                     }
                 ],

--- a/util/crucible-ci/oslat.remotehosts.json
+++ b/util/crucible-ci/oslat.remotehosts.json
@@ -8,8 +8,7 @@
                     {
                         "name": "common-params",
                         "params": [
-                            { "arg": "duration", "vals": [ "10" ], "role": "client" },
-                            { "arg": "rtprio", "vals": [ "1", "2" ], "role": "client" }
+                            { "arg": "duration", "vals": [ "10", "15" ], "role": "client" }
                         ]
                     }
                 ],


### PR DESCRIPTION
- checking to see if this improves reliability of oslat testing

- maintain multi-iteration by adding a second duration value