### PR TITLE
update rickshaw-run to only build a given image/tag once when force-b…

### DIFF
--- a/rickshaw-run
+++ b/rickshaw-run
@@ -118,6 +118,7 @@ my $roadblock_exit_abort_waiting = 6;
 my $abort_via_roadblock = 0;
 my $workshop_base_cmd;
 my $workshop_force_builds;
+my %workshop_built_tags;
 my $quay_refresh_expiration_token_file;
 my $quay_refresh_expiration_token;
 my $quay_refresh_expiration_api_url;
@@ -999,8 +1000,37 @@ sub source_container_image {
             exit 1;
         }
     } elsif ($workshop_force_builds eq "true") {
-        $i = -1;
-        printf "Image building is forced, need to build %d stage(s)\n", $num_images;
+        printf "Image building is forced, checking if any of the needed stages were already built during this run (1 to %d, %d being most complete)\n", $num_images, $num_images;
+        $i = $num_images - 1;
+        while ($i >= 0) {
+            debug_log(sprintf "Checking for stage number %d (of %d)\n", $i + 1, $num_images);
+            if (exists $workshop_built_tags{$workshop_args[$i]{'tag'}}) {
+                if (!remote_image_found($workshop_args[$i]{'tag'})) {
+                    if (!local_image_found($workshop_args[$i]{'tag'})) {
+                        printf "ERROR: Cannot find the image I was previously forced to build (%s)", $workshop_args[$i]{'tag'};
+                        exit 1;
+                    } else {
+                        push_local_image($workshop_args[$i]{'tag'});
+                        last;
+                    }
+                } else {
+                    last;
+                }
+            } else {
+                $i--;
+                next;
+            }
+        }
+        if ($i == -1) {
+            printf "Did not find any existing stages built during this run\n";
+        } elsif ($i < $num_images - 1) {
+            printf "Found stage number %d (of %d) built during this run, need to build %d stage(s)\n", $i + 1, $num_images, $num_images - 1 - $i;
+        } elsif ($i == $num_images - 1) {
+            printf "Found most complete stage built during this run (number %d)\n", $i + 1;
+        } else {
+            printf "Something went wrong searching for stages built during this run, stage number: %d, num_images: %d\n", $i + 1, $num_images;
+            exit 1;
+        }
     }
     $image = $run{'dest-image-url'} . ":" . $workshop_args[$i]{'tag'};
     # After finding the most complete image, build any "more" complete images until "most"
@@ -1113,6 +1143,7 @@ sub source_container_image {
         push_local_image($workshop_args[$i]{'tag'});
         $end = time();
         printf "\tPushing took %d seconds\n", $end - $begin;
+        $workshop_built_tags{$workshop_args[$i]{'tag'}} = 1;
         push(@local_images, $workshop_args[$i]{'tag'});
         $image = $run{'dest-image-url'} . ":" . $workshop_args[$i]{'tag'};
         $i++;


### PR DESCRIPTION
…uilds is enabled

- rickshaw-run will now keep a list of the images/tags it has built during a run and use that list to determine if an image should be built again or not -- if the image/tag is missing from the list then it should be built when force-builds is enabled