### PR TITLE
Fix `userenv.json` loading

### DIFF
--- a/rickshaw-run
+++ b/rickshaw-run
@@ -898,9 +898,10 @@ sub source_container_image {
     my @workshop_args;
     my $userenv_arg;
     my $count = 0;
-    (my $rc, my $userenv_ref) = get_json_file($rickshaw_project_dir . "/userenvs/" . $userenv . ".json");
+    my $userenv_file = $rickshaw_project_dir . "/userenvs/" . $userenv . "/userenv.json";
+    (my $rc, my $userenv_ref) = get_json_file($userenv_file);
     if ($rc != 0) {
-        die "ERROR: Could not load userenv JSON file for '" . $userenv . "' due to non-zero return code " . $rc . ".  Are you sure this is a supported userenv?\n";
+        die "ERROR: Could not load userenv JSON file for '" . $userenv_file . "' due to non-zero return code " . $rc . ".  Are you sure this is a supported userenv?\n";
     }
     my $userenv_image = $$userenv_ref{'userenv'}{'origin'}{'image'} . ":" . $$userenv_ref{'userenv'}{'origin'}{'tag'};
     while (scalar @requirements > 0) {


### PR DESCRIPTION
Userenv directory are in the for `./userenvs/<name>/userenv.json`

Change the loading path to avoid errors like:
```
Working on stream8 userenv
Sourcing container image for userenv 'stream8' and benchmark/tool 'iperf'; this may take a few minutes
ERROR: Could not load userenv JSON file for 'stream8' due to non-zero return code 8.  Are you sure this is a supported userenv?
Perl exited with active threads:
        0 running and unjoined
        1 finished and unjoined
        0 running and detached
Skipping run post-processing due to error(s) [rc=2]
```