### PR TITLE
change the engine code to use the python version of get-json-settings

### DIFF
--- a/engine/engine-script-library
+++ b/engine/engine-script-library
@@ -1163,7 +1163,7 @@ function load_json_setting() {
 
     echo "load_json_setting():"
 
-    value=$(${TOOLBOX_HOME}/bin/get-json-settings.pl --settings ${json_settings_file} --query ${query})
+    value=$(${TOOLBOX_HOME}/bin/get-json-settings.py --settings-file ${json_settings_file} --query ${query})
     if [ $? != 0 ]; then
         echo "available json settings:"
         xzcat ${json_settings_file}


### PR DESCRIPTION
- this sets the stage for removing perl from the engine environment entirely