### PR TITLE
add a build dependency package to components/rpm-core-compiling.json

### DIFF
--- a/userenvs/alma8.json
+++ b/userenvs/alma8.json
@@ -88,7 +88,8 @@
           "libnl3-devel",
           "numactl-devel",
           "java-1.8.0-openjdk",
-          "libpfm"
+          "libpfm",
+          "glibc-gconv-extra"
         ]
       }
     },

--- a/userenvs/alma9.json
+++ b/userenvs/alma9.json
@@ -88,7 +88,8 @@
           "libnl3-devel",
           "numactl-devel",
           "java-1.8.0-openjdk",
-          "libpfm"
+          "libpfm",
+          "glibc-gconv-extra"
         ]
       }
     },

--- a/userenvs/components/rpm-core-compiling.json
+++ b/userenvs/components/rpm-core-compiling.json
@@ -22,7 +22,8 @@
           "libnl3-devel",
           "numactl-devel",
           "java-1.8.0-openjdk",
-          "libpfm"
+          "libpfm",
+          "glibc-gconv-extra"
         ]
       }
     }

--- a/userenvs/fedora39.json
+++ b/userenvs/fedora39.json
@@ -88,7 +88,8 @@
           "libnl3-devel",
           "numactl-devel",
           "java-1.8.0-openjdk",
-          "libpfm"
+          "libpfm",
+          "glibc-gconv-extra"
         ]
       }
     },

--- a/userenvs/fedora40.json
+++ b/userenvs/fedora40.json
@@ -88,7 +88,8 @@
           "libnl3-devel",
           "numactl-devel",
           "java-1.8.0-openjdk",
-          "libpfm"
+          "libpfm",
+          "glibc-gconv-extra"
         ]
       }
     },

--- a/userenvs/rhubi8.json
+++ b/userenvs/rhubi8.json
@@ -100,7 +100,8 @@
           "libnl3-devel",
           "numactl-devel",
           "java-1.8.0-openjdk",
-          "libpfm"
+          "libpfm",
+          "glibc-gconv-extra"
         ]
       }
     },

--- a/userenvs/rhubi9.json
+++ b/userenvs/rhubi9.json
@@ -100,7 +100,8 @@
           "libnl3-devel",
           "numactl-devel",
           "java-1.8.0-openjdk",
-          "libpfm"
+          "libpfm",
+          "glibc-gconv-extra"
         ]
       }
     },

--- a/userenvs/stream8-flexran.json
+++ b/userenvs/stream8-flexran.json
@@ -84,7 +84,8 @@
           "libnl3-devel",
           "numactl-devel",
           "java-1.8.0-openjdk",
-          "libpfm"
+          "libpfm",
+          "glibc-gconv-extra"
         ]
       }
     },

--- a/userenvs/stream9.json
+++ b/userenvs/stream9.json
@@ -92,7 +92,8 @@
           "libnl3-devel",
           "numactl-devel",
           "java-1.8.0-openjdk",
-          "libpfm"
+          "libpfm",
+          "glibc-gconv-extra"
         ]
       }
     },


### PR DESCRIPTION
- this package is required to build certain packages in the Fedora 40 userenv, so adding it to the rpm-core-compiling requirement

- then rebuilding all active userenv's that depend on that requirement