### PR TITLE
remove benchmark choices from ci-run-file-creator.py

### DIFF
--- a/util/ci-run-file-creator.py
+++ b/util/ci-run-file-creator.py
@@ -45,7 +45,6 @@ def process_options():
                         dest = "benchmark",
                         help = "The benchmark to return a run-file for",
                         required = True,
-                        choices = [ "cyclictest", "fio", "iperf", "multi", "oslat", "uperf" ],
                         type = str)
 
     parser.add_argument("--controller-ip",


### PR DESCRIPTION
- the benchmark is already validated by the presence (or not) of a file to load

- having a list of choices means that there is yet another location to update when adding a new benchmark