### PR TITLE
bugfix: cast pids-limit to a string

### DIFF
--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -1149,7 +1149,7 @@ def create_podman(thread_name, remote_name, engine_name, container_name, connect
         create_cmd.append("--ipc=host") # only works when not using shm
 
     if "pids-limit" in podman_settings:
-        create_cmd.append("--pids-limit " + podman_settings["pids-limit"])
+        create_cmd.append("--pids-limit " + str(podman_settings["pids-limit"]))
 
     for mount in mandatory_mounts + host_mounts:
         if not "dest" in mount:


### PR DESCRIPTION
- pids-limit is defined as an integer in the JSON schema so it must be cast to a string to append it to a string