### PR TITLE
Randomly Generate Temporary Redis Password at Runtime

### DIFF
--- a/rickshaw-run
+++ b/rickshaw-run
@@ -23,6 +23,7 @@ use threads;
 use threads::shared;
 use Thread::Queue;
 use Thread::Semaphore;
+use Digest::SHA qw(sha256_hex);
 
 $Data::Dumper::Sortkeys = 1;
 $Data::Dumper::Pair = ' : ';
@@ -65,7 +66,21 @@ my @endpoints;
 my %image_ids; # {$benchmark-or-tool}{$userenv}
 my %run; # A multi-dimensional, nested hash, schema TBD
          # This hash documents what was run.
-my $redis_passwd = "flubber"; # TODO: make this cmdline setting
+
+
+my $random_file = "/dev/urandom";
+my $random_handle = undef;
+my $encoding = ":raw :bytes";
+my $BUFSIZ = 4096;
+
+open($random_handle, "< $encoding", $random_file) || die("[ERROR] Could not open /dev/urandom for reading\n");
+
+my $buffer;
+read($random_handle, $buffer, $BUFSIZ);
+my $passwd = sha256_hex($buffer);
+my $redis_passwd = "$passwd";
+
+
 my $rb_bin = "roadblocker.py";
 my $rb_module = "roadblock.py";
 my $messages_ref;


### PR DESCRIPTION
This implements solution (2) mentioned in https://github.com/perftool-incubator/rickshaw/issues/603. This will likely need some cleanup and testing as I am a perl novice.

The idea here is that we read 4096 bytes from /dev/urandom, then sha256 hash those bytes to get our random password. This password then replaces the previous hardcoded string.

This is a duplicate of #604 but merging from a branch of this repo.