### PR TITLE
Launch privileged pods for rtla on k8s

### DIFF
--- a/util/crucible-ci/hwnoise.k8s.json
+++ b/util/crucible-ci/hwnoise.k8s.json
@@ -56,6 +56,7 @@
                     "settings": {
                         "securityContext": {
                             "capabilities": {
+				"privileged": true,
                                 "add": [ "SYS_NICE", "IPC_LOCK" ]
                             }
                         }

--- a/util/crucible-ci/hwnoise.kube.json
+++ b/util/crucible-ci/hwnoise.kube.json
@@ -58,6 +58,7 @@
                     "settings": {
                         "securityContext": {
                             "capabilities": {
+				"privileged": true,
                                 "add": [ "SYS_NICE", "IPC_LOCK" ]
                             }
                         }


### PR DESCRIPTION
remotehosts podman osruntime runs privileged by default