### PR TITLE
support annotation and extra resource key:value pairs

### DIFF
--- a/endpoints/kube/kube.py
+++ b/endpoints/kube/kube.py
@@ -729,7 +729,12 @@ def create_pod_crd(role = None, id = None, node = None):
             "app": crd["metadata"]["name"]
         }
 
-    # handle annotations here
+    # handle annotations 
+    if role == "client" or role == "server":
+        if "annotations" in pod_settings:
+            if "annotations" not in crd["metadata"]:
+                crd["metadata"]["annotations"] = {}
+            crd["metadata"]["annotations"].update(copy.deepcopy(pod_settings["annotations"]))
 
     if role == "master":
         # ensure master pod can be scheduled on the master node in case

--- a/schema/kube.json
+++ b/schema/kube.json
@@ -237,6 +237,12 @@
             "type": "object",
             "minProperties": 1,
             "properties": {
+                "annotations": {
+                    "description": "Pod annotations to be applied to the associated engines. These are applied to the pod metadata.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "minProperties": 1
+                },
                 "cpu-partitioning": {
                     "description": "This parameter defines whether engines that have it assigned are to be configured with or without CPU partitioning enabled.",
                     "type": "boolean",
@@ -317,10 +323,10 @@
                                     "$ref": "#/definitions/memory"
                                 }
                             },
-                            "additionalProperties": false
+                            "additionalProperties": true
                         }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": true
                 },
                 "runtimeClassName": {
                     "description": "This parameter defines a runtime class that should be assigned to the associated engines.  See the K8S (or similar) documentation for more details about what this means and the possible values.",


### PR DESCRIPTION
Summary of changes:
===============
1. support the entire annotation section
                        "annotations": {
                            "v1.multus-cni.io/default-network": "default/default"
                        },

2. support the resources object where we can have other key:value pair beyond cpu and memory such as

                {
                    "settings": {
                        "resources": {
                            "openshift.io/reg_mlxnics": {
                                "requests": 1,
                                "limits": 1
                            },
                            "cpu": {
                                "requests": 21.0
                            }
                        },
                        "securityContext": {

Feel free to rework as you find suite.