### PR TITLE
feat: add K3s node detection to kube endpoint

### DIFF
--- a/endpoints/kube/kube.py
+++ b/endpoints/kube/kube.py
@@ -593,6 +593,11 @@ def get_k8s_config():
                 settings["misc"]["k8s"]["nodes"]["endpoint"]["masters"].append(name)
                 settings["misc"]["k8s"]["nodes"]["endpoint"]["workers"].append(name)
 
+            # k3s - single-node like microk8s
+            if "node-role.kubernetes.io/control-plane" in node["metadata"]["labels"]:
+                settings["misc"]["k8s"]["nodes"]["endpoint"]["masters"].append(name)
+                settings["misc"]["k8s"]["nodes"]["endpoint"]["workers"].append(name)
+
         node_count_fault = False
         logger.info("Found %d masters: %s" % (len(settings["misc"]["k8s"]["nodes"]["endpoint"]["masters"]), settings["misc"]["k8s"]["nodes"]["endpoint"]["masters"]))
         if len(settings["misc"]["k8s"]["nodes"]["endpoint"]["masters"]) == 0:


### PR DESCRIPTION
## Summary
- Add detection for K3s control-plane nodes using the `node-role.kubernetes.io/control-plane` label
- K3s single-node clusters are treated the same as microk8s (node counted as both master and worker)
- Enables kube endpoint to work with K3s distributions

## Problem
When using K3s, the kube endpoint was failing with "No masters found" and "No workers found" errors because it only had node detection logic for standard k8s and microk8s distributions.

## Solution
Added K3s node detection following the same pattern as microk8s (single-node treated as both master and worker), just using K3s's `node-role.kubernetes.io/control-plane` label instead of microk8s's `node.kubernetes.io/microk8s-controlplane` label.

## Test plan
- [ ] Verify existing microk8s support still works (CI should validate this)
- [ ] Test with K3s clusters to confirm node detection works
- [ ] Confirm no regression for standard k8s deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)