### PR TITLE
feat: add controller image requirements and use release CI workflow

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -35,10 +35,10 @@ jobs:
       - name: Display changes
         run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 
-  call-real-core-crucible-ci:
+  call-real-core-release-crucible-ci:
     needs: changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
-    uses: perftool-incubator/crucible-ci/.github/workflows/core-crucible-ci.yaml@main
+    uses: perftool-incubator/crucible-ci/.github/workflows/core-release-crucible-ci.yaml@main
     with:
       ci_target: "rickshaw"
       ci_target_branch: "${{ github.ref }}"
@@ -47,13 +47,13 @@ jobs:
       ci_registry_auth: ${{ secrets.CRUCIBLE_CI_ENGINES_REGISTRY_AUTH }}
       quay_oauth_token: ${{ secrets.CRUCIBLE_QUAYIO_OAUTH_TOKEN }}
 
-  call-faux-core-crucible-ci:
+  call-faux-core-release-crucible-ci:
     needs: changes
     if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
-    uses: perftool-incubator/crucible-ci/.github/workflows/faux-core-crucible-ci.yaml@main
+    uses: perftool-incubator/crucible-ci/.github/workflows/faux-core-release-crucible-ci.yaml@main
 
   crucible-ci-complete:
-    needs: [ call-real-core-crucible-ci, call-faux-core-crucible-ci ]
+    needs: [ call-real-core-release-crucible-ci, call-faux-core-release-crucible-ci ]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/workshop.json
+++ b/workshop.json
@@ -5,26 +5,75 @@
         }
     },
     "userenvs": [
-	{
-	    "name": "fedora",
-	    "requirements": [
-		"source-images-service-distro"
-	    ]
-	}
+        {
+            "name": "crucible-controller",
+            "requirements": [
+                "rickshaw-container-tools",
+                "endpoints-distro",
+                "source-images-service-distro",
+                "rickshaw-perl-modules",
+                "rickshaw-python-deps"
+            ]
+        }
     ],
     "requirements": [
-	{
-	    "name": "source-images-service-distro",
-	    "type": "distro",
-	    "distro_info": {
-		"packages": [
-		    "python3-fastapi",
-		    "python3-uvicorn+standard",
-		    "python3-pydantic",
-		    "python3-pydantic-settings",
-		    "python3-httpx"
-		]
-	    }
-	}
+        {
+            "name": "rickshaw-container-tools",
+            "type": "distro",
+            "distro_info": {
+                "packages": [
+                    "buildah",
+                    "skopeo"
+                ]
+            }
+        },
+        {
+            "name": "endpoints-distro",
+            "type": "distro",
+            "distro_info": {
+                "packages": [
+                    "python3-invoke",
+                    "python3-fabric",
+                    "python3-requests"
+                ]
+            }
+        },
+        {
+            "name": "source-images-service-distro",
+            "type": "distro",
+            "distro_info": {
+                "packages": [
+                    "python3-fastapi",
+                    "python3-uvicorn+standard",
+                    "python3-pydantic",
+                    "python3-pydantic-settings",
+                    "python3-httpx"
+                ]
+            }
+        },
+        {
+            "name": "rickshaw-perl-modules",
+            "type": "distro",
+            "distro_info": {
+                "packages": [
+                    "perl-JSON-XS",
+                    "perl-JSON-Validator",
+                    "perl-Data-UUID",
+                    "perl-Data-Dumper",
+                    "perl-REST-Client",
+                    "perl-Digest-MD5",
+                    "perl-Getopt-Long"
+                ]
+            }
+        },
+        {
+            "name": "rickshaw-python-deps",
+            "type": "python3",
+            "python3_info": {
+                "packages": [
+                    "jsonschema"
+                ]
+            }
+        }
     ]
 }

--- a/workshop.json
+++ b/workshop.json
@@ -14,6 +14,16 @@
                 "rickshaw-perl-modules",
                 "rickshaw-python-deps"
             ]
+        },
+        {
+            "name": "fedora",
+            "requirements": [
+                "rickshaw-container-tools",
+                "endpoints-distro",
+                "source-images-service-distro",
+                "rickshaw-perl-modules",
+                "rickshaw-python-deps"
+            ]
         }
     ],
     "requirements": [


### PR DESCRIPTION
## Summary
- Add Perl module and Python jsonschema dependencies to `workshop.json` for the controller image build
- Remove `fuse-overlayfs` from container-tools (crucible owns that) and remove `container-tools-config`
- Switch `crucible-ci.yaml` from `core-crucible-ci` to `core-release-crucible-ci` so workshop.json changes trigger a controller image rebuild

Part of the effort to decentralize controller image requirements to individual subprojects.

## Test plan
- [ ] CI passes
- [ ] Controller image builds successfully with rickshaw deps resolved from this workshop.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)