### PR TITLE
fix: multi-instance tool post-processing and log readability

### DIFF
--- a/engine/engine-script-library
+++ b/engine/engine-script-library
@@ -320,7 +320,7 @@ function validate_core_env() {
     # e.g. profiler-remotehost-1-sysstat-1,
     #      profiler-remotehost-1-rt-trace-bpf-1, profiler-k8s-sysstat-1,
     #      or profiler-kube-1-sysstat-1sec-1 (multi-instance tool ID with digits)
-    regex1='^profiler-([a-zA-Z0-9]+)-([0-9]+)-([a-zA-Z0-9_-]+)-([0-9]+)$'
+    regex1='^profiler-([a-zA-Z0-9]+)-([0-9]+)-([a-zA-Z0-9-]+)-([0-9]+)$'
 
     # client-1, server-1, or k8s-1
     regex2='^([a-zA-Z0-9]+)-([a-zA-Z0-9]+)$'

--- a/rickshaw-index
+++ b/rickshaw-index
@@ -931,15 +931,15 @@ if (-e $tool_dir and $index_tools == 1) {
         for my $collector (@collectors) {
                 my $collector_dir = $tool_dir . "/" . $collector;  # $run_dir/tool-data/[client|server|worker|master]
             if (opendir(COLLECTORDIR, $collector_dir)) {
-                my @numbers = grep (/\d+/, readdir(COLLECTORDIR));
-                for my $num (@numbers) {
-                    my $cd_id = $collector . "-" . $num;
-                    my $num_dir = $collector_dir . "/" . $num; # $run_dir/tool-data/[client|server|worker|master]/[0-N]
-                    log_print sprintf "Indexing of tool data for %s starting\n", $cd_id;
-                    if (opendir(NUMDIR, $num_dir)) {
-                        my @tools = grep(/\w+/, readdir(NUMDIR));
+                # engine directory entries: remotehost-1-sysstat-1 or kube-1-sysstat-1sec-1
+                my @engines = grep (/^[a-zA-Z0-9]+-\d+-[a-zA-Z0-9-]+-\d+$/, readdir(COLLECTORDIR));
+                for my $engine (@engines) {
+                    my $engine_dir = $collector_dir . "/" . $engine;
+                    log_print sprintf "Indexing of tool data for %s/%s starting\n", $collector, $engine;
+                    if (opendir(ENGDIR, $engine_dir)) {
+                        my @tools = grep(/\w+/, readdir(ENGDIR));
                         for my $tool (@tools) {
-                            my $tool_dir = $num_dir . "/" . $tool;
+                            my $tool_dir = $engine_dir . "/" . $tool;
                             if (opendir(TOOLDIR, $tool_dir)) {
                                 my @tool_files = grep(/metric-data-\S+\.json/, readdir(TOOLDIR));
                                 for my $tool_file (@tool_files) {
@@ -950,7 +950,7 @@ if (-e $tool_dir and $index_tools == 1) {
                                     my %job_args = ( 'tool-dir' => $tool_dir,
                                                      'tool-file' => $tool_file,
                                                      'collector' => $collector,
-                                                     'num' => $num,
+                                                     'num' => $engine,
                                                      'doc-ref' => $base_metric_doc_ref );
                                     push(@jobs, \%job_args);
 

--- a/rickshaw-post-process-tools
+++ b/rickshaw-post-process-tools
@@ -217,8 +217,8 @@ if (opendir(TOOLDIR, $run_dir . "/" . $tool_dir)) {
     for my $collector (@collectors) {
         my $collector_dir = $tool_dir . "/" . $collector;  # $run_dir/tool-data/[client|server|worker|master|profiler]
         if (opendir(COLLECTORDIR, $run_dir . "/" . $collector_dir)) {
-        # sample directory entry: remotehost-1-kernel-1
-            my @engines = grep (/\w+-\d+-\w+-\d+/, readdir(COLLECTORDIR));
+            # sample directory entry: remotehost-1-kernel-1 or kube-1-sysstat-1sec-1
+            my @engines = grep (/^[a-zA-Z0-9]+-\d+-[a-zA-Z0-9-]+-\d+$/, readdir(COLLECTORDIR));
             for my $engine (@engines) {
                 my $engine_dir = $collector_dir . "/" . $engine; # $run_dir/tool-data/[client|server|worker|master]/[0-N]
                 if (opendir(ENGDIR, $run_dir . "/" . $engine_dir)) {

--- a/rickshaw-run
+++ b/rickshaw-run
@@ -2343,15 +2343,18 @@ sub deploy_endpoints() {
     # Deploy ths endpoints so they are ready to run benchmark and tools.
     # Each endpoint is responible for launching a osruntime for each client and server.
     my %remote_hosts;
-    log_print "\nDeploying endpoints\n";
+
+    log_print "\nCalculating dynamic roadblock timeout values:\n";
     $endpoint_deploy_timeout += scalar @endpoints * 120;
     foreach my $engine (keys %clients_servers) {
         $endpoint_deploy_timeout += scalar @{ $clients_servers{$engine} } * 15;
         $engine_script_start_timeout += scalar @{ $clients_servers{$engine} } * 15;
     }
-    log_print sprintf "endpoint-deploy-timeout adjusted to %d seconds\n", $endpoint_deploy_timeout;
-    log_print sprintf "engine-script-timeout adjusted to %d seconds\n", $endpoint_deploy_timeout;
+    log_print sprintf "  endpoint-deploy-timeout adjusted to %d seconds\n", $endpoint_deploy_timeout;
+    log_print sprintf "  engine-script-timeout adjusted to %d seconds\n", $endpoint_deploy_timeout;
+
     debug_log(sprintf "\nendpoint output:\n");
+    log_print "\nDeploying endpoints:\n\n";
     for (my $i = 0; $i < scalar @endpoints; $i++) {
         my $type = $endpoints[$i]{'type'};
         my $opts = $endpoints[$i]{'opts'};


### PR DESCRIPTION
## Summary
- Fixes engine directory matching in `rickshaw-post-process-tools` and `rickshaw-index` for multi-instance tool IDs (e.g., `kube-1-sysstat-1sec-1`)
- Tightens regexes with anchoring and character classes that align with what the tool-params schema allows
- Renames misleading `@numbers`/`$num` variables to `@engines`/`$engine` in `rickshaw-index`
- Updates `engine-script-library` cs_label regex to match tightened pattern
- Separates dynamic roadblock timeout calculation from endpoint deployment log messages for readability

## Test plan
- [ ] Run with multi-instance tools — verify post-processing and indexing complete successfully
- [ ] Run with single-instance tools — verify no regression
- [ ] Verify result-summary shows all tool metric sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)