### PR TITLE
feat: change default workshop script from workshop.pl to workshop.py

### DIFF
--- a/rickshaw-run
+++ b/rickshaw-run
@@ -55,7 +55,7 @@ my @utilities = ( "packrat" );
 my $jsonsettings;
 my $registries_settings;
 my $use_workshop = 0;
-my $workshop_script = "workshop.pl";
+my $workshop_script = "workshop.py";
 my %bench_configs;
 my %bench_dirs;
 my %benchmark_to_ids;
@@ -162,7 +162,7 @@ sub usage {
     log_print "--json-validator         Path to json schema validation utility\n";
     log_print "--engine-dir             Directory where the engine project exists\n";
     log_print "--workshop-dir           Directory where workshop project exists\n";
-    log_print "--workshop-script        Workshop script filename (workshop.pl or workshop.py, default: workshop.pl)\n";
+    log_print "--workshop-script        Workshop script filename (default: workshop.py)\n";
     log_print "--packrat-dir            Directory where the packrat project exists\n";
     log_print "--roadblock-dir          Directory where workshop project exists\n";
     log_print "--roadblock-password     Password to use to access the valkey instance\n";
@@ -901,7 +901,7 @@ sub validate_controller_env() {
         log_print "ERROR, roadblock project directory not defined or roadblocker.py not found";
         exit 1;
     }
-    $workshop_script = $run{'workshop-script'} // $ENV{'WORKSHOP_SCRIPT'} // "workshop.pl";
+    $workshop_script = $run{'workshop-script'} // $ENV{'WORKSHOP_SCRIPT'} // "workshop.py";
     if (defined $run{'workshop-dir'} and -e $run{'workshop-dir'} . "/$workshop_script") {
         $use_workshop = 1;
         if ( ! exists $run{'registries'}{'public'}{'repo'} ) {

--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -193,7 +193,7 @@ class RunState:
         self.jsonsettings = {}
         self.registries_settings = None
         self.use_workshop = 0
-        self.workshop_script = "workshop.pl"
+        self.workshop_script = "workshop.py"
         self.workshop_force_builds = ""
         self.bench_configs = {}
         self.bench_dirs = {}
@@ -426,7 +426,7 @@ class RunState:
         logger.info("--external-userenvs-dir  Path to look for userenv definitions in that are provided by external sources")
         logger.info("--engine-dir             Directory where the engine project exists")
         logger.info("--workshop-dir           Directory where workshop project exists")
-        logger.info("--workshop-script        Workshop script filename (workshop.pl or workshop.py, default: workshop.pl)")
+        logger.info("--workshop-script        Workshop script filename (default: workshop.py)")
         logger.info("--packrat-dir            Directory where the packrat project exists")
         logger.info("--roadblock-dir          Directory where workshop project exists")
         logger.info("--roadblock-password     Password to use to access the valkey instance")
@@ -726,7 +726,7 @@ class RunState:
             logger.error("ERROR, roadblock project directory not defined or roadblocker.py not found")
             sys.exit(1)
 
-        self.workshop_script = self.run.get("workshop-script") or os.environ.get("WORKSHOP_SCRIPT") or "workshop.pl"
+        self.workshop_script = self.run.get("workshop-script") or os.environ.get("WORKSHOP_SCRIPT") or "workshop.py"
         if "workshop-dir" in self.run and os.path.exists(os.path.join(self.run["workshop-dir"], self.workshop_script)):
             self.use_workshop = 1
             pub_reg = self.run.get("registries", {}).get("public", {})

--- a/rickshaw-source-images-client
+++ b/rickshaw-source-images-client
@@ -315,7 +315,7 @@ def _build_api_request(input_data):
     # --- Workshop ---
     workshop_script = os.environ.get(
         "WORKSHOP_SCRIPT",
-        input_data.get("workshop", {}).get("script", "workshop.pl"),
+        input_data.get("workshop", {}).get("script", "workshop.py"),
     )
     workshop_script_path = os.path.join(workshop_dir, workshop_script) if workshop_dir else ""
     schema_path = os.path.join(workshop_dir, "schema.json") if workshop_dir else ""

--- a/source-images-service/source_images_service/core/workspace.py
+++ b/source-images-service/source_images_service/core/workspace.py
@@ -32,7 +32,7 @@ class WorkspacePaths:
     config: Path = field(init=False)
     registries: Path = field(init=False)
     build: Path = field(init=False)
-    workshop_script: str = "workshop.pl"
+    workshop_script: str = "workshop.py"
 
     def __post_init__(self) -> None:
         self.workshop = self.root / "workshop"

--- a/source-images-service/source_images_service/models/requests.py
+++ b/source-images-service/source_images_service/models/requests.py
@@ -58,9 +58,9 @@ class WorkshopConfig(BaseModel):
         description="Base64-encoded workshop script",
     )
     workshop_script: str = Field(
-        default="workshop.pl",
+        default="workshop.py",
         alias="workshop-script",
-        description="Workshop script filename: workshop.pl or workshop.py",
+        description="Workshop script filename (default: workshop.py)",
     )
     schema_content: str = Field(
         alias="schema-content",


### PR DESCRIPTION
## Summary
- Change the default workshop script from `workshop.pl` to `workshop.py` in all locations
- Update help text to remove the now-redundant "workshop.pl or workshop.py" phrasing

The Python workshop script has been the standard for a while — `bin/_main` always passes `--workshop-script=workshop.py`. This change aligns the defaults so the fallback matches actual usage.

## Test plan
- [ ] CI passes (crucible-ci exercises the workshop path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)