### PR TITLE
feat: remove workshop.pl from source-images-input schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Key modules under `source_images_service/`:
 
 ## Workshop Integration
 
-The workshop script (`workshop.pl` or `workshop.py`) builds container images. The `--workshop-script` flag (or `WORKSHOP_SCRIPT` env var) selects which script to use, defaulting to `workshop.pl`. This flows through:
+The workshop script (`workshop.py`) builds container images. The `--workshop-script` flag (or `WORKSHOP_SCRIPT` env var) can override the default. This flows through:
 1. `rickshaw-run` → input JSON (`workshop.script`)
 2. `rickshaw-source-images-client` → reads from JSON/env
 3. `source-images-service` → `WorkshopConfig.workshop_script` field

--- a/schema/source-images-input.json
+++ b/schema/source-images-input.json
@@ -121,7 +121,7 @@
                 "script": {
                     "type": "string",
                     "description": "Workshop script filename to use for image builds.",
-                    "enum": ["workshop.pl", "workshop.py"]
+                    "enum": ["workshop.py"]
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
## Summary
- Remove `workshop.pl` from the `workshop.script` enum in `schema/source-images-input.json`
- Update CLAUDE.md workshop integration section

Companion to perftool-incubator/workshop#112 which removes `workshop.pl` from the workshop repo.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)