### PR TITLE
fix: remove stale profiled-nodes append that corrupts pod list

### DIFF
--- a/endpoints/kube/kube.py
+++ b/endpoints/kube/kube.py
@@ -1691,7 +1691,6 @@ def create_tools_pods(abort_event):
                     logger.info("Already profiling worker node '%s' and I'm not really sure why..." % (node))
             else:
                 logger.info("Adding worker node '%s' to the list of profiled nodes because is hosting engine pods" % (node))
-                settings["engines"]["endpoint"]["classes"]["profiled-nodes"].append(node)
                 profiled_nodes.append(node)
 
         for node in settings["misc"]["k8s"]["nodes"]["endpoint"]["workers"]:


### PR DESCRIPTION
## Summary
- Remove stale append of raw node name strings to `settings[...]["profiled-nodes"]`
- This list is later iterated expecting pod dicts with `role`, `id`, and `crd` keys
- On clusters with dedicated workers (not also masters), the raw strings corrupt the list and cause failures when accessing `pod["role"]`
- Follow-up to e51daf3 which moved the list initialization but didn't remove this stale append

## Test plan
- [ ] Run a benchmark on a multi-node cluster with separate master and worker nodes
- [ ] Verify profiler pods are created and launched correctly on all profiled nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)