### PR TITLE
feat: switch endpoints/base from get-json-settings.pl to .py

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -1141,7 +1141,7 @@ function load_json_setting() {
         echo "load_json_setting():"
     fi
 
-    value=$(${TOOLBOX_HOME}/bin/get-json-settings.pl --settings "${config_dir}/rickshaw-settings.json.xz" --query ${query})
+    value=$(${TOOLBOX_HOME}/bin/get-json-settings.py --settings-file "${config_dir}/rickshaw-settings.json.xz" --query ${query} 2>/dev/null)
     if [ $? != 0 ]; then
         echo "available json settings:"
         xzcat "${config_dir}/rickshaw-settings.json.xz"


### PR DESCRIPTION
## Summary
- Switch the last caller of `get-json-settings.pl` in `endpoints/base` to use the Python version (`get-json-settings.py`)
- Adjusts `--settings` to `--settings-file` to match the Python CLI interface
- Redirects stderr to suppress info-level log messages from stdout capture
- Enables removal of `toolbox/bin/get-json-settings.pl` once this merges

## Test plan
- [ ] Run a benchmark that exercises endpoint settings loading (roadblock timeouts, userenv, endpoint user)
- [ ] Verified Perl and Python versions produce identical output for string, integer, and float queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)