### PR TITLE
fix: reject unexpected lines in endpoint validation output

### DIFF
--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -944,6 +944,11 @@ class RunState:
                     for bench_name in self.bench_configs:
                         self.image_ids.setdefault(bench_name, {})[userenv] = {"image": ""}
 
+                else:
+                    logger.error("[ERROR] output from endpoint validation incorrect for %s:\n%s",
+                                 endpoint["label"], line)
+                    sys.exit(1)
+
         if len(self.bench_configs) == 1:
             bench_name = list(self.bench_configs.keys())[0]
             all_ids = sorted(self.clients_servers.get("client", {}).keys(), key=int)


### PR DESCRIPTION
## Summary
- Add missing else clause to endpoint validation output parsing in rickshaw-run.py
- The Perl version rejected any non-comment line that didn't match expected patterns (engine-types, client/server/profiler, userenv) with exit 1
- The Python port silently ignored these lines, allowing ERROR: messages from validate_error() to pass undetected
- This caused runs to proceed past failed validation (e.g., SSH auth failures) instead of aborting

## Test plan
- [ ] Run with a valid endpoint — validates and proceeds normally
- [ ] Run with an endpoint that fails validation (e.g., bad SSH key) — exits with error instead of continuing

🤖 Generated with [Claude Code](https://claude.com/claude-code)