### PR TITLE
feat: add --log-level support with verbose and debug levels

### DIFF
--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -31,6 +31,7 @@ if RICKSHAW_HOME:
 from toolbox.fileio import open_write_text_file
 from toolbox.json import load_json_file, save_json_file
 from toolbox.jsonsettings import get_json_setting
+import logging
 from toolbox.logging import setup_logging
 from toolbox.roadblock import do_roadblock as toolbox_do_roadblock, ROADBLOCK_EXITS
 from toolbox.run import run_cmd
@@ -258,6 +259,10 @@ class RunState:
                 sys.exit(1)
 
             p = p[2:]
+            if p == "help":
+                self.usage()
+                sys.exit(0)
+
             if "=" in p:
                 arg, val = p.split("=", 1)
             else:
@@ -281,9 +286,6 @@ class RunState:
                     sys.exit(1)
             elif arg == "log-level":
                 pass
-            elif arg == "help":
-                self.usage()
-                sys.exit(0)
             elif re.match(
                 r'^(base-run-dir|workshop-dir|workshop-script|packrat-dir|bench-dir|'
                 r'roadblock-dir|roadblock-password|tools-dir|engine-dir|'
@@ -2008,6 +2010,12 @@ def main():
         elif arg.startswith("--log-level="):
             log_level = arg.split("=", 1)[1]
     logger = setup_logging("rickshaw-run", log_level)
+    # At normal level, suppress library INFO (e.g. roadblock) for curated
+    # output. Raise the root logger to WARNING while keeping our own logger
+    # at INFO. Use --log-level=verbose to see library INFO output.
+    if log_level == "normal":
+        logger.setLevel(logging.INFO)
+        logging.getLogger().setLevel(logging.WARNING)
     logger.info("rickshaw-run.py starting")
 
     state = RunState()

--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -279,7 +279,7 @@ class RunState:
                 else:
                     logger.error("[ERROR] malformed endpoint: %s", val)
                     sys.exit(1)
-            elif arg == "debug":
+            elif arg == "log-level":
                 pass
             elif arg == "help":
                 self.usage()
@@ -436,6 +436,7 @@ class RunState:
         logger.info("--tool-params            File with tool parameters to use")
         logger.info("--num-samples            The number of sample executions to run for each benchmark iteration")
         logger.info("--max-sample-failures    The total number of benchmark sample executions that are tolerated")
+        logger.info("--log-level              Logging verbosity: normal, verbose, or debug (default: normal)")
         logger.info("--test-order             's' = run all samples of an iteration first")
         logger.info("                         'i' = run all iterations of a sample first")
         logger.info("                         'r' = run a sample from a random iteration one at a time")
@@ -2000,7 +2001,13 @@ class RunState:
 
 def main():
     global logger
-    logger = setup_logging("rickshaw-run", "normal")
+    log_level = "normal"
+    for i, arg in enumerate(sys.argv[1:]):
+        if arg == "--log-level" and i + 2 < len(sys.argv):
+            log_level = sys.argv[i + 2]
+        elif arg.startswith("--log-level="):
+            log_level = arg.split("=", 1)[1]
+    logger = setup_logging("rickshaw-run", log_level)
     logger.info("rickshaw-run.py starting")
 
     state = RunState()


### PR DESCRIPTION
## Summary
- Replace `--debug` (which was a no-op) with `--log-level` accepting `normal`, `verbose`, or `debug`
- At normal level, suppress library INFO output (roadblock, etc.) by raising the root logger to WARNING while keeping rickshaw-run's own logger at INFO for curated output
- At verbose level, library INFO becomes visible (e.g. roadblock's 95 info messages)
- At debug level, full diagnostic output with code location and thread info
- Fix `--help` parsing to handle it before the value-consuming logic
- Depends on toolbox #112 (merged) for VERBOSE level and root logger configuration

## Test plan
- [ ] `--log-level=normal` — curated output, no roadblock INFO
- [ ] `--log-level=verbose` — roadblock INFO visible with timestamps
- [ ] `--log-level=debug` — full diagnostic output with code location
- [ ] `--help` — prints usage and exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)