### PR TITLE
feat: multi-architecture image sourcing and endpoint arch detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,16 @@ The workshop script (`workshop.py`) builds container images. The `--workshop-scr
 2. `rickshaw-source-images-client.py` → reads from JSON/env
 3. `source-images-service` → `WorkshopConfig.workshop_script` field
 
+## Multi-Architecture Image Sourcing
+
+Endpoints detect and report their CPU architecture(s) during validation via the `arch` keyword (e.g., `arch x86_64 aarch64`). The kube endpoint reads `node.status.nodeInfo.architecture` from `kubectl get nodes --output json` and normalizes K8s names to Linux names (`amd64` → `x86_64`, `arm64` → `aarch64`). The remotehosts endpoint runs `uname -m` on each remote host.
+
+`rickshaw-run.py` collects required architectures across all endpoints and routes image sourcing requests to per-arch service URLs read from `image-sourcing-urls.json` (written by crucible's `bin/_main`). When multiple architectures are needed, sourcing runs in parallel. The `--image` format passed to endpoints includes architecture: `role::userenv::arch::image_url`. The `get_image()` and `get_engine_id_image()` functions in `endpoints/endpoints.py` accept an optional `arch` parameter.
+
+For the kube endpoint, the `arch` setting in `schema/kube.json` lets users target a specific architecture without writing a raw `kubernetes.io/arch` nodeSelector. On multi-arch clusters without explicit arch constraints, the endpoint defaults to the controller's native architecture and adds a `kubernetes.io/arch` nodeSelector automatically.
+
+The source-images-service validates that `request.arch` matches `platform.machine()` at the start of each job, preventing architecture mismatches from producing incorrectly-tagged images. The `/api/v1/health` endpoint reports the service's native architecture.
+
 ## CI
 
 GitHub Actions workflows in `.github/workflows/`:

--- a/endpoints/endpoints.py
+++ b/endpoints/endpoints.py
@@ -1850,15 +1850,17 @@ def init_settings(settings, args):
     settings["misc"]["image-map"] = dict()
     images = args.images.split(",")
     for image in images:
-        image_split = image.split("::", maxsplit=2)
-        role = image_split[0]
-        userenv = image_split[1]
-        image = image_split[2]
-        if not role in settings["misc"]["image-map"]:
-            logger.info("Adding role %s to image-map" % (role))
-            settings["misc"]["image-map"][role] = dict()
-        logger.info("Adding %s to userenv %s for role %s to image-map" % (image, userenv, role))
-        settings["misc"]["image-map"][role][userenv] = image
+        parts = image.split("::")
+        if len(parts) == 4:
+            role, userenv, arch, image_url = parts
+            settings["misc"]["image-map"].setdefault(role, {}).setdefault(userenv, {})[arch] = image_url
+            logger.info("Adding %s to userenv %s arch %s for role %s to image-map" % (image_url, userenv, arch, role))
+        elif len(parts) == 3:
+            role, userenv, image_url = parts
+            if not role in settings["misc"]["image-map"]:
+                settings["misc"]["image-map"][role] = dict()
+            settings["misc"]["image-map"][role][userenv] = image_url
+            logger.info("Adding %s to userenv %s for role %s to image-map" % (image_url, userenv, role))
 
     log_settings(settings, mode = "misc")
 
@@ -2070,7 +2072,7 @@ def get_benchmark(settings, benchmark_id):
 
     return None
 
-def get_image(settings, image_role, userenv):
+def get_image(settings, image_role, userenv, arch=None):
     """
     Get the image that is used to run a specific benchmark/tool
 
@@ -2078,6 +2080,8 @@ def get_image(settings, image_role, userenv):
         settings (dict): the one data structure to rule then all
         image_role (str): The tool or benchmark whose container image is being asked for
         userenv (str): The userenv whose container image is being asked for
+        arch (str): The target CPU architecture (e.g., 'x86_64', 'aarch64').
+                    If None, falls back to legacy non-arch-keyed lookup.
 
     Globals:
         logger: a logger instance
@@ -2088,16 +2092,27 @@ def get_image(settings, image_role, userenv):
         None: If no matching container image can be located
     """
     if image_role in settings["misc"]["image-map"]:
-        if userenv in settings["misc"]["image-map"][image_role]:
-            return settings["misc"]["image-map"][image_role][userenv]
+        userenv_map = settings["misc"]["image-map"][image_role].get(userenv)
+        if userenv_map is None:
+            logger.error("Could not find userenv %s in image-map[%s]" % (userenv, image_role))
+            return None
+        if isinstance(userenv_map, dict) and arch:
+            if arch in userenv_map:
+                return userenv_map[arch]
+            else:
+                logger.error("Could not find arch %s in image-map[%s][%s]" % (arch, image_role, userenv))
+                return None
+        elif isinstance(userenv_map, str):
+            return userenv_map
         else:
-            logger.error("Could not find userenv %s in image-map[%s]" % (userenv, image_role));
+            logger.error("Unexpected image-map format for %s / %s" % (image_role, userenv))
+            return None
     else:
         logger.error("Could not find image_role %s in image-map" % (image_role))
 
     return None
 
-def get_engine_id_image(settings, role, id, userenv):
+def get_engine_id_image(settings, role, id, userenv, arch=None):
     """
     Get the image associated with a specific engine role and ID
 
@@ -2106,6 +2121,8 @@ def get_engine_id_image(settings, role, id, userenv):
         role (str): The engine's role
         id (str, int): The engine's ID
         userenv (str): The engine's userenv
+        arch (str): The target CPU architecture (e.g., 'x86_64', 'aarch64').
+                    If None, falls back to non-arch-keyed lookup.
 
     Globals:
         None
@@ -2123,7 +2140,7 @@ def get_engine_id_image(settings, role, id, userenv):
         case _:
             image_role = get_benchmark(settings, id)
     if not image_role is None:
-        image = get_image(settings, image_role, userenv)
+        image = get_image(settings, image_role, userenv, arch=arch)
     return image
 
 def get_profiler_userenv(settings, id):

--- a/endpoints/kube/kube.py
+++ b/endpoints/kube/kube.py
@@ -10,6 +10,7 @@ import jsonschema
 import logging
 import lzma
 import os
+import platform
 from paramiko import ssh_exception
 from pathlib import Path
 import re
@@ -37,6 +38,7 @@ else:
         print("ERROR: <TOOLBOX_HOME>/python ('%s') does not exist!" % (p))
         exit(2)
     sys.path.append(str(p))
+import json as json_module
 from toolbox.json import *
 
 endpoint_default_settings = {
@@ -580,11 +582,30 @@ def validate():
                 if result.exited != 0:
                     endpoints.validate_error("Failed to run '%s version' on endpoint host '%s' as user '%s'" % (k8s_bin, endpoint_settings["host"], endpoint_settings["user"]))
 
-                result = endpoints.run_remote(con, k8s_bin + " get nodes", validate = True, debug = debug_output, env = remote_env)
-                result.stdout = re.sub(r'\n', ' | ', result.stdout)
-                endpoints.validate_comment("remote '%s' functional check for %s: rc=%d stdout=[%s] and stderr=[%s]" % (k8s_bin, endpoint_settings["host"], result.exited, result.stdout.rstrip(' | '), result.stderr.rstrip('\n')))
+                result = endpoints.run_remote(con, k8s_bin + " get nodes --output json", validate = True, debug = debug_output, env = remote_env)
                 if result.exited != 0:
+                    result.stdout = re.sub(r'\n', ' | ', result.stdout)
+                    endpoints.validate_comment("remote '%s' functional check for %s: rc=%d stdout=[%s] and stderr=[%s]" % (k8s_bin, endpoint_settings["host"], result.exited, result.stdout.rstrip(' | '), result.stderr.rstrip('\n')))
                     endpoints.validate_error("Failed to functionally verify '%s' on endpoint host '%s' as user '%s'" % (k8s_bin, endpoint_settings["host"], endpoint_settings["user"]))
+                else:
+                    endpoints.validate_comment("remote '%s' functional check for %s: rc=%d" % (k8s_bin, endpoint_settings["host"], result.exited))
+
+                    k8s_to_linux_arch = {
+                        "amd64": "x86_64",
+                        "arm64": "aarch64",
+                        "ppc64le": "ppc64le",
+                        "s390x": "s390x",
+                    }
+                    cluster_archs = set()
+                    nodes_data = json_module.loads(result.stdout)
+                    for node in nodes_data.get("items", []):
+                        k8s_arch = node.get("status", {}).get("nodeInfo", {}).get("architecture", "")
+                        if k8s_arch:
+                            cluster_archs.add(k8s_to_linux_arch.get(k8s_arch, k8s_arch))
+
+                    if cluster_archs:
+                        endpoints.validate_comment("detected cluster architectures: %s" % (sorted(cluster_archs)))
+                        endpoints.validate_log("arch %s" % (" ".join(sorted(cluster_archs))))
     except ssh_exception.AuthenticationException as e:
         endpoints.validate_error("remote login verification for %s with user %s resulted in an authentication exception '%s'" % (endpoint_settings["host"], endpoint_settings["user"], str(e)))
     except ssh_exception.NoValidConnectionsError as e:
@@ -833,11 +854,27 @@ def get_k8s_config():
             logger.error("Did not find any nodes")
             return 1
 
+        k8s_to_linux_arch = {
+            "amd64": "x86_64",
+            "arm64": "aarch64",
+            "ppc64le": "ppc64le",
+            "s390x": "s390x",
+        }
+        linux_to_k8s_arch = {v: k for k, v in k8s_to_linux_arch.items()}
+
         masters = set()
         workers = set()
+        cluster_archs = set()
+        node_arch_map = {}
         for node in settings["misc"]["k8s"]["nodes"]["cluster"]["items"]:
             name = node["metadata"]["name"]
             labels = node["metadata"]["labels"]
+
+            k8s_arch = node.get("status", {}).get("nodeInfo", {}).get("architecture", "")
+            if k8s_arch:
+                linux_arch = k8s_to_linux_arch.get(k8s_arch, k8s_arch)
+                cluster_archs.add(linux_arch)
+                node_arch_map[name] = linux_arch
 
             if "node-role.kubernetes.io/master" in labels or "node-role.kubernetes.io/control-plane" in labels:
                 masters.add(name)
@@ -853,6 +890,11 @@ def get_k8s_config():
         # master node also serves as the worker (e.g., k3s, minikube)
         if len(workers) == 0 and len(masters) == 1:
             workers = set(masters)
+
+        settings["misc"]["k8s"]["cluster-archs"] = sorted(cluster_archs)
+        settings["misc"]["k8s"]["node-arch-map"] = node_arch_map
+        settings["misc"]["k8s"]["linux-to-k8s-arch"] = linux_to_k8s_arch
+        logger.info("Cluster architectures: %s" % (sorted(cluster_archs)))
 
         settings["misc"]["k8s"]["nodes"]["endpoint"]["masters"] = sorted(masters)
         settings["misc"]["k8s"]["nodes"]["endpoint"]["workers"] = sorted(workers)
@@ -1140,6 +1182,32 @@ def create_job_crd(role = None, id = None, node = None, node_tools = None, cs_en
             mapping["ids"].append(engine_name)
             container_names.append(engine_name)
 
+    # Determine the target architecture for this pod
+    target_arch = None
+    cluster_archs = settings["misc"]["k8s"].get("cluster-archs", [])
+    node_arch_map = settings["misc"]["k8s"].get("node-arch-map", {})
+    linux_to_k8s_arch = settings["misc"]["k8s"].get("linux-to-k8s-arch", {})
+
+    if is_cs_pod and "arch" in pod_settings:
+        target_arch = pod_settings["arch"]
+        pod_spec.setdefault("nodeSelector", {})["kubernetes.io/arch"] = linux_to_k8s_arch.get(target_arch, target_arch)
+        logger.info("Engine arch setting specifies '%s', adding kubernetes.io/arch nodeSelector" % (target_arch))
+    elif "nodeSelector" in pod_spec and "kubernetes.io/arch" in pod_spec["nodeSelector"]:
+        k8s_to_linux_arch = {v: k for k, v in linux_to_k8s_arch.items()}
+        target_arch = k8s_to_linux_arch.get(pod_spec["nodeSelector"]["kubernetes.io/arch"], pod_spec["nodeSelector"]["kubernetes.io/arch"])
+    elif "nodeSelector" in pod_spec and "kubernetes.io/hostname" in pod_spec["nodeSelector"]:
+        target_node = pod_spec["nodeSelector"]["kubernetes.io/hostname"]
+        target_arch = node_arch_map.get(target_node)
+    elif len(cluster_archs) == 1:
+        target_arch = cluster_archs[0]
+    else:
+        target_arch = platform.machine()
+        if len(cluster_archs) > 1:
+            pod_spec.setdefault("nodeSelector", {})["kubernetes.io/arch"] = linux_to_k8s_arch.get(target_arch, target_arch)
+            logger.info("Multi-arch cluster with no arch constraint, defaulting to '%s' with kubernetes.io/arch nodeSelector" % (target_arch))
+
+    logger.info("Target architecture for pod '%s': %s" % (name, target_arch))
+
     pod_spec["containers"] = []
     for container_name in container_names:
         logger.info("Adding container '%s' to job" % (container_name))
@@ -1147,7 +1215,7 @@ def create_job_crd(role = None, id = None, node = None, node_tools = None, cs_en
         if is_cs_pod:
             engine = container_engine_map[container_name]
             engine_settings = endpoint["engines"]["settings"][engine["role"]][engine["id"]]
-            image = endpoints.get_engine_id_image(settings, engine["role"], engine["id"], engine_settings["userenv"])
+            image = endpoints.get_engine_id_image(settings, engine["role"], engine["id"], engine_settings["userenv"], arch=target_arch)
         elif role == "worker" or role == "master":
             userenv = endpoints.get_profiler_userenv(settings, container_name)
             if userenv is None:
@@ -1155,7 +1223,7 @@ def create_job_crd(role = None, id = None, node = None, node_tools = None, cs_en
                 return None, 1
             else:
                 logger.info("Found userenv '%s' for engine '%s'" % (userenv, container_name))
-            image = endpoints.get_engine_id_image(settings, role, container_name, userenv)
+            image = endpoints.get_engine_id_image(settings, role, container_name, userenv, arch=target_arch)
         if image is None:
             logger.error("Could not find image for container %s" % (container_name))
             return None, 1

--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -10,6 +10,7 @@ from fabric import Connection
 import jsonschema
 import logging
 import os
+import platform
 from paramiko import ssh_exception
 from pathlib import Path
 import queue
@@ -172,12 +173,17 @@ def validate():
     debug_output = False
     if args.log_level == "debug":
         debug_output = True
+    remote_archs = set()
     for remote in remotes.keys():
         for remote_user in remotes[remote].keys():
             try:
                 with endpoints.remote_connection(remote, remote_user, validate = True) as c:
-                    result = endpoints.run_remote(c, "uptime", validate = True, debug = debug_output)
-                    endpoints.validate_comment("remote login verification for %s with user %s: rc=%d and stdout=[%s] annd stderr=[%s]" % (remote, remote_user, result.exited, result.stdout.rstrip('\n'), result.stderr.rstrip('\n')))
+                    # uname -m serves dual purpose: verifies SSH connectivity and detects architecture
+                    result = endpoints.run_remote(c, "uname -m", validate = True, debug = debug_output)
+                    host_arch = result.stdout.strip()
+                    endpoints.validate_comment("remote login and architecture check for %s with user %s: rc=%d arch=%s" % (remote, remote_user, result.exited, host_arch))
+                    if result.exited == 0 and host_arch:
+                        remote_archs.add(host_arch)
 
                     result = endpoints.run_remote(c, "podman --version", validate = True, debug = debug_output)
                     endpoints.validate_comment("remote podman presence check for %s: rc=%d and stdout=[%s] and stderr=[%s]" % (remote, result.exited, result.stdout.rstrip('\n'), result.stderr.rstrip('\n')))
@@ -192,6 +198,10 @@ def validate():
                 endpoints.validate_error("remote login verification for %s with user %s resulted in an authentication exception '%s'" % (remote, remote_user, str(e)))
             except ssh_exception.NoValidConnectionsError as e:
                 endpoints.validate_error("remote login verification for %s with user %s resulted in an connection exception '%s'" % (remote, remote_user, str(e)))
+
+    if remote_archs:
+        endpoints.validate_comment("detected remote host architectures: %s" % (sorted(remote_archs)))
+        endpoints.validate_log("arch %s" % (" ".join(sorted(remote_archs))))
 
     return 0
 
@@ -357,6 +367,18 @@ def build_unique_remote_configs():
         for role in settings["engines"]["remotes"][remote]["roles"].keys():
             if "ids" in settings["engines"]["remotes"][remote]["roles"][role]:
                 settings["engines"]["remotes"][remote]["roles"][role]["ids"].sort()
+
+    # Detect architecture for each remote host
+    for remote in settings["engines"]["remotes"].keys():
+        my_run_file_remote = settings["run-file"]["endpoints"][args.endpoint_index]["remotes"][settings["engines"]["remotes"][remote]["run-file-idx"][0]]
+        with endpoints.remote_connection(remote, my_run_file_remote["config"]["settings"]["remote-user"]) as con:
+            result = endpoints.run_remote(con, "uname -m")
+            if result.exited == 0:
+                settings["engines"]["remotes"][remote]["arch"] = result.stdout.strip()
+                logger.info("Remote %s architecture: %s" % (remote, settings["engines"]["remotes"][remote]["arch"]))
+            else:
+                logger.warning("Could not detect architecture for remote %s, defaulting to controller arch" % (remote))
+                settings["engines"]["remotes"][remote]["arch"] = platform.machine()
 
     profiler_count = 0
     for remote in settings["engines"]["remotes"].keys():
@@ -683,7 +705,8 @@ def remotes_pull_images():
                     logger.error("Cound not find userenv for remote %s with role %s and id %s" % (remote, role, str(id)))
                     print("could not find userenv for " + endpoint)
                 else:
-                    image = endpoints.get_engine_id_image(settings, role, id, userenv)
+                    remote_arch = settings["engines"]["remotes"][remote].get("arch")
+                    image = endpoints.get_engine_id_image(settings, role, id, userenv, arch=remote_arch)
 
                 if image is None:
                     logger.error("Could not find image for remote %s with role %s and id %s" % (remote, role, str(id)))
@@ -1237,7 +1260,8 @@ def launch_engines_worker_thread(thread_id, work_queue, threads_rcs):
                     else:
                         userenv = settings["run-file"]["endpoints"][args.endpoint_index]["remotes"][remote_idx]["config"]["settings"]["userenv"]
 
-                    image = endpoints.get_engine_id_image(settings, engine["role"], engine_id, userenv)
+                    remote_arch = settings["engines"]["remotes"][remote["config"]["host"]].get("arch")
+                    image = endpoints.get_engine_id_image(settings, engine["role"], engine_id, userenv, arch=remote_arch)
                     if image is None:
                         thread_logger("Could not determine image", log_level = "error", remote_name = remote_name, engine_name = engine_name)
                         continue

--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -230,6 +230,8 @@ class RunState:
         self.endpoint_processes = []
 
         self.arch = platform.machine()
+        self.required_archs = set()
+        self.arch_urls = {}
         self.available_cpus = os.cpu_count() or 1
 
         signal.signal(signal.SIGINT, self._sigint_handler)
@@ -280,12 +282,14 @@ class RunState:
                     sys.exit(1)
             elif arg == "log-level":
                 pass
+            elif arg == "source-images-service-url":
+                logger.debug("ignoring legacy --source-images-service-url (using image-sourcing-urls.json instead)")
             elif re.match(
                 r'^(base-run-dir|workshop-dir|workshop-script|packrat-dir|bench-dir|'
                 r'roadblock-dir|roadblock-password|tools-dir|engine-dir|'
                 r'run-id|id|bench-params|tool-params|'
                 r'test-order|tool-group|num-samples|max-sample-failures|name|bench-ids|'
-                r'registries-json|external-userenvs-dir|source-images-service-url|'
+                r'registries-json|external-userenvs-dir|'
                 r'email|desc)$', arg
             ):
                 logger.debug("argument: [%s]", arg)
@@ -933,18 +937,34 @@ class RunState:
                     for etype in parts[1:]:
                         self.active_collector_types[etype] = 1
 
+                elif keyword == "arch":
+                    endpoint["archs"] = parts[1:]
+                    logger.debug("endpoint %s reports architectures: %s",
+                                 endpoint["label"], endpoint["archs"])
+
                 elif keyword == "userenv":
                     userenv = parts[1] if len(parts) > 1 else ""
                     endpoint["userenvs"].append(userenv)
                     logger.debug("clients/servers for endpoint %s will have userenv %s",
                                  endpoint["label"], userenv)
-                    for bench_name in self.bench_configs:
-                        self.image_ids.setdefault(bench_name, {})[userenv] = {"image": ""}
 
                 else:
                     logger.error("[ERROR] output from endpoint validation incorrect for %s:\n%s",
                                  endpoint["label"], line)
                     sys.exit(1)
+
+        for endpoint in self.endpoints:
+            if "archs" in endpoint:
+                self.required_archs.update(endpoint["archs"])
+        if not self.required_archs:
+            self.required_archs.add(self.arch)
+        logger.info("Required architectures across all endpoints: %s", sorted(self.required_archs))
+
+        for endpoint in self.endpoints:
+            for userenv in endpoint.get("userenvs", []):
+                for arch in endpoint.get("archs", [self.arch]):
+                    for bench_name in self.bench_configs:
+                        self.image_ids.setdefault(arch, {}).setdefault(bench_name, {})[userenv] = {"image": ""}
 
         if len(self.bench_configs) == 1:
             bench_name = list(self.bench_configs.keys())[0]
@@ -1063,7 +1083,8 @@ class RunState:
                 self.tools_configs[tool_name] = tool_cfg
 
             self.bench_dirs[tool_id] = os.path.join(self.run["tools-dir"], tool_name)
-            self.image_ids.setdefault(tool_id, {})[tool_entry["userenv"]] = {"image": ""}
+            for arch in self.required_archs:
+                self.image_ids.setdefault(arch, {}).setdefault(tool_id, {})[tool_entry["userenv"]] = {"image": ""}
 
         save_json_file(os.path.join(self.config_dir, "tool-id-map.json"), tool_id_map)
 
@@ -1364,38 +1385,13 @@ class RunState:
             else:
                 self.build_files_list(cs_type)
 
-    def source_images(self):
-        logger.info("Preparing userenvs:")
-        logger.debug("image_ids (before): %s", json.dumps(self.image_ids, indent=2, default=str))
-
-        dedup_image_ids = {}
-        dedup_bench_dirs = {}
-        for tid in list(self.image_ids.keys()):
-            tool_name = tid
-            for tool_entry in self.tools_params:
-                if tool_entry["tool-id"] == tid:
-                    tool_name = tool_entry["tool"]
-                    break
-            if tid in self.bench_dirs:
-                dedup_bench_dirs[tool_name] = self.bench_dirs[tid]
-            for userenv in self.image_ids[tid]:
-                dedup_image_ids.setdefault(tool_name, {})[userenv] = self.image_ids[tid][userenv]
-
-        for bench in self.bench_dirs:
-            if bench not in dedup_bench_dirs and not any(t["tool-id"] == bench for t in self.tools_params):
-                dedup_bench_dirs[bench] = self.bench_dirs[bench]
-
-        utility_dirs = {}
-        for utility in UTILITIES:
-            utility_dir_key = f"{utility}-dir"
-            if utility_dir_key in self.run:
-                utility_dirs[utility] = self.run[utility_dir_key]
-
+    def _source_images_for_arch(self, arch, service_url, dedup_image_ids, dedup_bench_dirs, utility_dirs, provenance):
+        """Source images for a single architecture. Returns (arch, output_ref, error_msg)."""
         source_input = {
             "image-ids": dedup_image_ids,
             "registries": self.run.get("registries", {}),
             "registries-json": self.run.get("registries-json", ""),
-            "arch": self.arch,
+            "arch": arch,
             "bench-dirs": dedup_bench_dirs,
             "utilities": UTILITIES,
             "dirs": {
@@ -1415,56 +1411,147 @@ class RunState:
         }
         if "external-userenvs-dir" in self.run:
             source_input["external-userenvs-dir"] = self.run["external-userenvs-dir"]
-
-        provenance = self._build_provenance(utility_dirs)
         source_input["provenance"] = provenance
 
-        source_input_file = os.path.join(self.config_dir, "image-source-input.json")
-        source_output_file = os.path.join(self.config_dir, "image-source-output.json")
+        source_input_file = os.path.join(self.config_dir, f"image-source-input-{arch}.json")
+        source_output_file = os.path.join(self.config_dir, f"image-source-output-{arch}.json")
         save_json_file(source_input_file, source_input)
-
-        if "source-images-service-url" not in self.run:
-            logger.error("[ERROR] --source-images-service-url is required")
-            sys.exit(1)
 
         source_images_cmd = (
             f"{self.rickshaw_project_dir}/rickshaw-source-images-client.py"
             f" --input {source_input_file}"
             f" --output {source_output_file}"
-            f" --service-url {self.run['source-images-service-url']}"
+            f" --service-url {service_url}"
         )
-        logger.info("Running: %s", source_images_cmd)
-        rc = subprocess.run(source_images_cmd, shell=True).returncode
+        logger.info("Running (%s): %s", arch, source_images_cmd)
+        if len(self.required_archs) > 1:
+            prefix = f"[{arch}] "
+            proc = subprocess.Popen(source_images_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+            for line in proc.stdout:
+                print(f"{prefix}{line}", end="")
+            rc = proc.wait()
+        else:
+            rc = subprocess.run(source_images_cmd, shell=True).returncode
         if rc != 0:
-            logger.error("rickshaw-source-images-client.py failed with exit code %d", rc)
-            sys.exit(1)
+            return (arch, None, f"rickshaw-source-images-client.py failed for {arch} with exit code {rc}")
 
         output_ref, err = load_json_file(source_output_file)
         if output_ref is None:
             output_ref, err = load_json_file(source_output_file + ".xz", uselzma=True)
         if output_ref is None:
-            logger.error("Failed to read image source output JSON: %s", source_output_file)
+            return (arch, None, f"Failed to read image source output JSON for {arch}: {source_output_file}")
+
+        return (arch, output_ref, None)
+
+    def source_images(self):
+        logger.info("Preparing userenvs:")
+        logger.debug("image_ids (before): %s", json.dumps(self.image_ids, indent=2, default=str))
+
+        # Load per-architecture image sourcing service URLs
+        urls_file = os.path.join(self.config_dir, "image-sourcing-urls.json")
+        self.arch_urls, err = load_json_file(urls_file)
+        if self.arch_urls is None:
+            logger.error("[ERROR] Failed to read %s: %s", urls_file, err)
             sys.exit(1)
 
+        for arch in self.required_archs:
+            if arch not in self.arch_urls:
+                logger.error("[ERROR] No image sourcing service URL configured for architecture '%s'", arch)
+                logger.error("  Available architectures: %s", list(self.arch_urls.keys()))
+                sys.exit(1)
+
+        # Deduplicate image IDs and bench dirs (same for all architectures)
+        dedup_bench_dirs = {}
+        dedup_image_ids = {}
+        for arch in self.image_ids:
+            for tid in list(self.image_ids[arch].keys()):
+                tool_name = tid
+                for tool_entry in self.tools_params:
+                    if tool_entry["tool-id"] == tid:
+                        tool_name = tool_entry["tool"]
+                        break
+                if tid in self.bench_dirs:
+                    dedup_bench_dirs[tool_name] = self.bench_dirs[tid]
+                for userenv in self.image_ids[arch][tid]:
+                    dedup_image_ids.setdefault(tool_name, {})[userenv] = self.image_ids[arch][tid][userenv]
+
+        for bench in self.bench_dirs:
+            if bench not in dedup_bench_dirs and not any(t["tool-id"] == bench for t in self.tools_params):
+                dedup_bench_dirs[bench] = self.bench_dirs[bench]
+
+        utility_dirs = {}
+        for utility in UTILITIES:
+            utility_dir_key = f"{utility}-dir"
+            if utility_dir_key in self.run:
+                utility_dirs[utility] = self.run[utility_dir_key]
+
+        provenance = self._build_provenance(utility_dirs)
+
+        # Source images in parallel — one call per required architecture
+        source_errors = 0
+        if len(self.required_archs) == 1:
+            arch = list(self.required_archs)[0]
+            arch_result, output_ref, error_msg = self._source_images_for_arch(
+                arch, self.arch_urls[arch], dedup_image_ids, dedup_bench_dirs, utility_dirs, provenance
+            )
+            if error_msg:
+                logger.error(error_msg)
+                source_errors += 1
+            else:
+                self._merge_source_output(arch, output_ref)
+        else:
+            with ThreadPoolExecutor(max_workers=len(self.required_archs)) as executor:
+                futures = {}
+                for arch in sorted(self.required_archs):
+                    future = executor.submit(
+                        self._source_images_for_arch,
+                        arch, self.arch_urls[arch], dedup_image_ids, dedup_bench_dirs, utility_dirs, provenance
+                    )
+                    futures[future] = arch
+
+                for future in as_completed(futures):
+                    arch_result, output_ref, error_msg = future.result()
+                    if error_msg:
+                        logger.error(error_msg)
+                        source_errors += 1
+                    else:
+                        self._merge_source_output(arch_result, output_ref)
+
+        if source_errors > 0:
+            logger.error("[ERROR] %d architecture(s) failed image sourcing", source_errors)
+            sys.exit(1)
+
+        logger.info("Userenv image summary:")
+        missing_images = []
+        for arch in sorted(self.image_ids.keys()):
+            for bench_or_tool in sorted(self.image_ids[arch].keys()):
+                for userenv in sorted(self.image_ids[arch][bench_or_tool].keys()):
+                    image = self.image_ids[arch][bench_or_tool][userenv]["image"]
+                    display_image = re.sub(r'::.*', '', image)
+                    logger.info("  %s / %s / %s: %s", arch, bench_or_tool, userenv, display_image)
+                    if not image:
+                        missing_images.append(f"{arch} / {bench_or_tool} / {userenv}")
+
+        if missing_images:
+            logger.error("[ERROR] The following image(s) were not resolved during sourcing:")
+            for entry in missing_images:
+                logger.error("  %s", entry)
+            sys.exit(1)
+
+        logger.debug("image_ids (after): %s", json.dumps(self.image_ids, indent=2, default=str))
+
+    def _merge_source_output(self, arch, output_ref):
+        """Merge image sourcing output into self.image_ids for the given architecture."""
         for name in output_ref.get("image-ids", {}):
             for userenv in output_ref["image-ids"][name]:
                 image = output_ref["image-ids"][name][userenv]["image"]
-                if name in self.image_ids:
-                    self.image_ids[name][userenv]["image"] = image
+                if arch in self.image_ids and name in self.image_ids[arch]:
+                    self.image_ids[arch][name][userenv]["image"] = image
                 for tool_entry in self.tools_params:
                     if tool_entry["tool"] == name and tool_entry["tool-id"] != name:
                         tool_id = tool_entry["tool-id"]
-                        if tool_id in self.image_ids and userenv in self.image_ids[tool_id]:
-                            self.image_ids[tool_id][userenv]["image"] = image
-
-        logger.info("Userenv image summary:")
-        for bench_or_tool in sorted(self.image_ids.keys()):
-            for userenv in sorted(self.image_ids[bench_or_tool].keys()):
-                image = self.image_ids[bench_or_tool][userenv]["image"]
-                image = re.sub(r'::.*', '', image)
-                logger.info("  %s / %s: %s", bench_or_tool, userenv, image)
-
-        logger.debug("image_ids (after): %s", json.dumps(self.image_ids, indent=2, default=str))
+                        if arch in self.image_ids and tool_id in self.image_ids[arch] and userenv in self.image_ids[arch][tool_id]:
+                            self.image_ids[arch][tool_id][userenv]["image"] = image
 
     def _build_provenance(self, utility_dirs):
         provenance = {}
@@ -1655,18 +1742,22 @@ class RunState:
             endpoint_image_opt = ""
 
             if "userenvs" in endpoint:
+                endpoint_archs = endpoint.get("archs", [self.arch])
                 for userenv in endpoint["userenvs"]:
-                    for bench_or_tool in self.image_ids:
-                        chosen_userenv = userenv
-                        idx = find_index(self.tools_params, "tool-id", bench_or_tool)
-                        if idx > -1:
-                            chosen_userenv = self.tools_params[idx]["userenv"]
-                        if chosen_userenv not in self.image_ids.get(bench_or_tool, {}):
-                            logger.error("ERROR: image for %s / userenv %s not found in image_ids",
-                                         bench_or_tool, chosen_userenv)
-                            sys.exit(1)
-                        image = self.image_ids[bench_or_tool][chosen_userenv]["image"]
-                        endpoint_image_opt += f",{bench_or_tool}::{chosen_userenv}::{image}"
+                    for arch in endpoint_archs:
+                        if arch not in self.image_ids:
+                            continue
+                        for bench_or_tool in self.image_ids[arch]:
+                            chosen_userenv = userenv
+                            idx = find_index(self.tools_params, "tool-id", bench_or_tool)
+                            if idx > -1:
+                                chosen_userenv = self.tools_params[idx]["userenv"]
+                            if chosen_userenv not in self.image_ids[arch].get(bench_or_tool, {}):
+                                logger.error("ERROR: image for %s / %s / userenv %s not found in image_ids",
+                                             arch, bench_or_tool, chosen_userenv)
+                                sys.exit(1)
+                            image = self.image_ids[arch][bench_or_tool][chosen_userenv]["image"]
+                            endpoint_image_opt += f",{bench_or_tool}::{chosen_userenv}::{arch}::{image}"
                 if endpoint_image_opt:
                     endpoint_image_opt = f" --image={endpoint_image_opt.lstrip(',')}"
 

--- a/schema/kube.json
+++ b/schema/kube.json
@@ -412,6 +412,14 @@
                     "type": "object",
                     "minProperties": 1
                 },
+                "arch": {
+                    "description": "This parameter defines the target CPU architecture for the associated engines.  When set, a kubernetes.io/arch nodeSelector is automatically added to ensure pods are scheduled on nodes of the specified architecture.  Valid values match Linux architecture names.",
+                    "type": "string",
+                    "enum": [
+                        "x86_64",
+                        "aarch64"
+                    ]
+                },
                 "cpu-partitioning": {
                     "description": "This parameter defines whether engines that have it assigned are to be configured with or without CPU partitioning enabled.",
                     "type": "boolean",

--- a/source-images-service/source_images_service/api/v1/endpoints/health.py
+++ b/source-images-service/source_images_service/api/v1/endpoints/health.py
@@ -1,5 +1,7 @@
 """Health check endpoint."""
 
+import platform
+
 from fastapi import APIRouter, Request
 
 from source_images_service.models.responses import HealthResponse
@@ -16,6 +18,7 @@ async def health_check(request: Request) -> dict:
     return {
         "status": "healthy",
         "version": config.version,
+        "arch": platform.machine(),
         "active-jobs": active,
         "pending-jobs": pending,
     }

--- a/source-images-service/source_images_service/core/image_sourcer.py
+++ b/source-images-service/source_images_service/core/image_sourcer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import platform
 import re
 import time
 from datetime import datetime, timezone
@@ -1078,6 +1079,14 @@ def source_all_images(job: Job, build_coordinator: BuildCoordinator) -> dict[str
 
     request = job.request
     workspace = job.workspace
+
+    native_arch = platform.machine()
+    if request.arch != native_arch:
+        raise SourceImagesError(
+            f"Architecture mismatch: this service runs on {native_arch} "
+            f"but received a request for {request.arch} images. "
+            f"Check services.json to ensure the correct service URL is mapped to each architecture."
+        )
 
     image_ids: dict[str, dict[str, dict[str, Any]]] = {}
     workshop_built_tags: dict[str, int] = {}

--- a/source-images-service/source_images_service/models/responses.py
+++ b/source-images-service/source_images_service/models/responses.py
@@ -66,6 +66,7 @@ class HealthResponse(BaseModel):
 
     status: str
     version: str
+    arch: str
     active_jobs: int = Field(alias="active-jobs")
     pending_jobs: int = Field(alias="pending-jobs")
 


### PR DESCRIPTION
## Summary

- Endpoints detect and report their CPU architecture(s) during validation via the `arch` keyword
- Kube endpoint reads `node.status.nodeInfo.architecture` from node JSON, normalizes K8s names (`amd64`→`x86_64`, `arm64`→`aarch64`), and stores per-node arch mappings for image selection
- Remotehosts endpoint replaces `uptime` SSH check with `uname -m` for dual-purpose connectivity + arch detection, and detects arch again during deployment for image lookups
- `rickshaw-run.py` collects required architectures across all endpoints, loads per-arch service URLs from `image-sourcing-urls.json` (written by crucible's `bin/_main`), and sources images in parallel — one call per architecture
- Image delivery to endpoints extended with arch: `role::userenv::arch::image_url` format
- `get_image()` and `get_engine_id_image()` accept optional `arch` parameter for per-arch image map lookups
- Unresolved images detected and reported before endpoint deployment
- Source-images-service validates `request.arch` matches `platform.machine()` to prevent architecture-mismatched builds; health endpoint reports native arch
- New optional `arch` setting in kube schema allows targeting a specific architecture without writing a raw `kubernetes.io/arch` nodeSelector

## Depends on

- [crucible#584](https://github.com/perftool-incubator/crucible/pull/584) (merged) — per-arch `services.json` and `image-sourcing-urls.json` generation

## Key files

| File | Change |
|---|---|
| `rickshaw-run.py` | `arch` keyword parsing, per-arch `image_ids`, parallel sourcing, unresolved image check |
| `endpoints/endpoints.py` | 4-part `--image` format, `get_image()`/`get_engine_id_image()` with `arch` param |
| `endpoints/kube/kube.py` | Node arch detection, cluster arch storage, arch-based image selection, auto `kubernetes.io/arch` nodeSelector |
| `endpoints/remotehosts/remotehosts.py` | `uname -m` for validation + deployment, per-host arch in image lookups |
| `schema/kube.json` | Optional `arch` engine setting (`x86_64`, `aarch64`) |
| `source-images-service/.../image_sourcer.py` | Arch mismatch guard |
| `source-images-service/.../health.py` | `arch` field in health response |
| `source-images-service/.../responses.py` | `arch` field in `HealthResponse` model |
| `CLAUDE.md` | Multi-arch image sourcing documentation |

## Test plan

- [ ] Single-arch remotehosts run: verify `arch` keyword in validation output, no regression
- [ ] Single-arch kube run: verify `arch` keyword with correct node architectures
- [ ] Multi-arch remotehosts run with remote native builder: verify parallel sourcing, correct per-host images
- [ ] Kube `arch` schema setting: verify `kubernetes.io/arch` nodeSelector is added
- [ ] Architecture mismatch: send wrong arch to SIS, verify rejection
- [ ] Missing images: verify fatal error before endpoint deployment if any images unresolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)