### PR TITLE
feat: remove legacy --source-images-service-url CLI arg

### DIFF
--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -282,8 +282,6 @@ class RunState:
                     sys.exit(1)
             elif arg == "log-level":
                 pass
-            elif arg == "source-images-service-url":
-                logger.debug("ignoring legacy --source-images-service-url (using image-sourcing-urls.json instead)")
             elif re.match(
                 r'^(base-run-dir|workshop-dir|workshop-script|packrat-dir|bench-dir|'
                 r'roadblock-dir|roadblock-password|tools-dir|engine-dir|'


### PR DESCRIPTION
## Summary

- Remove the `--source-images-service-url` handler from `rickshaw-run.py` that was silently ignoring the arg
- Crucible no longer passes this arg (removed in [crucible#585](https://github.com/perftool-incubator/crucible/pull/585)), so the handler is dead code
- Rickshaw exclusively uses `image-sourcing-urls.json` for per-arch service URLs

## Test plan

- [ ] `crucible run` — verify run succeeds with no reference to `--source-images-service-url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)