### PR TITLE
fix: CI workflow fixes for fork-check permissions and only_changed

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -13,7 +13,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      only-docs: ${{ steps.filter.outputs.only_changed }}
+      only-docs: ${{ steps.filter.outputs.only_modified }}
     steps:
       - uses: actions/checkout@v4
       - id: filter

--- a/.github/workflows/fork-check.yaml
+++ b/.github/workflows/fork-check.yaml
@@ -2,7 +2,11 @@ name: fork-check
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   block-fork-pr:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -13,7 +13,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      only-docs: ${{ steps.filter.outputs.only_changed }}
+      only-docs: ${{ steps.filter.outputs.only_modified }}
     steps:
       - uses: actions/checkout@v4
       - id: filter


### PR DESCRIPTION
## Summary

Two CI workflow fixes:

1. **fork-check.yaml**: Add `permissions` block (`issues: write`, `pull-requests: write`) and broaden event types to include `synchronize` and `edited`. Without the permissions, the GITHUB_TOKEN for `pull_request_target` events from forks only has read access, causing the comment and close API calls to fail silently with 403.

2. **only_changed→only_modified**: The `tj-actions/changed-files` `only_changed` output does not include deleted files, causing CI to be skipped when a PR only deletes non-doc files. Switch to `only_modified` in `crucible-ci.yaml` and `unittest.yaml`.

## Test plan

- [ ] Fork-check: verified working on bench-trafficgen#106 (merged)
- [ ] only_modified: verify CI runs correctly on a PR that deletes files

🤖 Generated with [Claude Code](https://claude.com/claude-code)