### PR TITLE
fix: handle private registry auth token in image map parsing

### DIFF
--- a/endpoints/endpoints.py
+++ b/endpoints/endpoints.py
@@ -1851,7 +1851,12 @@ def init_settings(settings, args):
     images = args.images.split(",")
     for image in images:
         parts = image.split("::")
-        if len(parts) == 4:
+        if len(parts) == 5:
+            role, userenv, arch, image_url, auth_file = parts
+            image_value = image_url + "::" + auth_file
+            settings["misc"]["image-map"].setdefault(role, {}).setdefault(userenv, {})[arch] = image_value
+            logger.info("Adding %s to userenv %s arch %s for role %s to image-map" % (image_value, userenv, arch, role))
+        elif len(parts) == 4:
             role, userenv, arch, image_url = parts
             settings["misc"]["image-map"].setdefault(role, {}).setdefault(userenv, {})[arch] = image_url
             logger.info("Adding %s to userenv %s arch %s for role %s to image-map" % (image_url, userenv, arch, role))
@@ -1861,6 +1866,8 @@ def init_settings(settings, args):
                 settings["misc"]["image-map"][role] = dict()
             settings["misc"]["image-map"][role][userenv] = image_url
             logger.info("Adding %s to userenv %s for role %s to image-map" % (image_url, userenv, role))
+        else:
+            logger.warning("Unexpected image format with %d fields: %s" % (len(parts), image))
 
     log_settings(settings, mode = "misc")
 


### PR DESCRIPTION
## Summary
- Fix regression from multi-arch image sourcing (commit 4c96743) where private registry images with auth token paths were silently dropped from the endpoint image map
- The parser was changed from `split("::", maxsplit=2)` to `split("::")` with strict 3/4 field checks, but private registries produce a 5th field (`role::userenv::arch::image_url::auth_file`)
- Add `len(parts) == 5` handling that rejoins image URL and auth file with `::` before storing, preserving the format kube.py and remotehosts.py expect
- Add warning log for unexpected field counts instead of silent drops

## Test plan
- [ ] Run a benchmark using a private registry image (e.g., uperf with rhel10.2 userenv) and confirm the image appears in the image-map log
- [ ] Confirm the endpoint successfully pulls the image using the extracted auth token
- [ ] Confirm public registry images (4-field entries) continue working unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)