### PR TITLE
feat: support split workshop files for role-specific engine images

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -194,8 +194,10 @@ function process_opts() {
                 shift;
                 for bench_and_image in `echo $image | sed -e 's/,/ /g'`; do
                     bench=`echo $bench_and_image | awk -F:: '{print $1}'`
-                    userenv=`echo $bench_and_image | awk -F:: '{print $2}'`
-                    image=`echo $bench_and_image | awk -F:: '{print $3}'`
+                    engine_role=`echo $bench_and_image | awk -F:: '{print $2}'`
+                    userenv=`echo $bench_and_image | awk -F:: '{print $3}'`
+                    arch=`echo $bench_and_image | awk -F:: '{print $4}'`
+                    image=`echo $bench_and_image | awk -F:: '{print $5}'`
                     bench_to_image[$bench]=$image
                 done
                 ;;

--- a/endpoints/endpoints.py
+++ b/endpoints/endpoints.py
@@ -1851,21 +1851,15 @@ def init_settings(settings, args):
     images = args.images.split(",")
     for image in images:
         parts = image.split("::")
-        if len(parts) == 5:
-            role, userenv, arch, image_url, auth_file = parts
+        if len(parts) == 6:
+            bench, engine_role, userenv, arch, image_url, auth_file = parts
             image_value = image_url + "::" + auth_file
-            settings["misc"]["image-map"].setdefault(role, {}).setdefault(userenv, {})[arch] = image_value
-            logger.info("Adding %s to userenv %s arch %s for role %s to image-map" % (image_value, userenv, arch, role))
-        elif len(parts) == 4:
-            role, userenv, arch, image_url = parts
-            settings["misc"]["image-map"].setdefault(role, {}).setdefault(userenv, {})[arch] = image_url
-            logger.info("Adding %s to userenv %s arch %s for role %s to image-map" % (image_url, userenv, arch, role))
-        elif len(parts) == 3:
-            role, userenv, image_url = parts
-            if not role in settings["misc"]["image-map"]:
-                settings["misc"]["image-map"][role] = dict()
-            settings["misc"]["image-map"][role][userenv] = image_url
-            logger.info("Adding %s to userenv %s for role %s to image-map" % (image_url, userenv, role))
+            settings["misc"]["image-map"].setdefault(bench, {}).setdefault(engine_role, {}).setdefault(userenv, {})[arch] = image_value
+            logger.info("Adding %s to role %s userenv %s arch %s for bench %s to image-map" % (image_value, engine_role, userenv, arch, bench))
+        elif len(parts) == 5:
+            bench, engine_role, userenv, arch, image_url = parts
+            settings["misc"]["image-map"].setdefault(bench, {}).setdefault(engine_role, {}).setdefault(userenv, {})[arch] = image_url
+            logger.info("Adding %s to role %s userenv %s arch %s for bench %s to image-map" % (image_url, engine_role, userenv, arch, bench))
         else:
             logger.warning("Unexpected image format with %d fields: %s" % (len(parts), image))
 
@@ -2079,13 +2073,14 @@ def get_benchmark(settings, benchmark_id):
 
     return None
 
-def get_image(settings, image_role, userenv, arch=None):
+def get_image(settings, image_role, engine_role, userenv, arch=None):
     """
     Get the image that is used to run a specific benchmark/tool
 
     Args:
         settings (dict): the one data structure to rule then all
         image_role (str): The tool or benchmark whose container image is being asked for
+        engine_role (str): The engine role ('client', 'server', or 'all')
         userenv (str): The userenv whose container image is being asked for
         arch (str): The target CPU architecture (e.g., 'x86_64', 'aarch64').
                     If None, falls back to legacy non-arch-keyed lookup.
@@ -2098,26 +2093,38 @@ def get_image(settings, image_role, userenv, arch=None):
         or
         None: If no matching container image can be located
     """
-    if image_role in settings["misc"]["image-map"]:
-        userenv_map = settings["misc"]["image-map"][image_role].get(userenv)
-        if userenv_map is None:
-            logger.error("Could not find userenv %s in image-map[%s]" % (userenv, image_role))
-            return None
-        if isinstance(userenv_map, dict) and arch:
-            if arch in userenv_map:
-                return userenv_map[arch]
-            else:
-                logger.error("Could not find arch %s in image-map[%s][%s]" % (arch, image_role, userenv))
-                return None
-        elif isinstance(userenv_map, str):
-            return userenv_map
-        else:
-            logger.error("Unexpected image-map format for %s / %s" % (image_role, userenv))
-            return None
-    else:
+    if image_role not in settings["misc"]["image-map"]:
         logger.error("Could not find image_role %s in image-map" % (image_role))
+        return None
 
-    return None
+    bench_map = settings["misc"]["image-map"][image_role]
+
+    if engine_role not in bench_map:
+        logger.error("Could not find engine_role %s in image-map[%s]" % (engine_role, image_role))
+        return None
+
+    role_map = bench_map[engine_role]
+    userenv_map = role_map.get(userenv)
+    if userenv_map is None:
+        if engine_role != "all":
+            for avail_userenv in role_map:
+                userenv_map = role_map[avail_userenv]
+                break
+        if userenv_map is None:
+            logger.error("Could not find userenv %s in image-map[%s][%s]" % (userenv, image_role, engine_role))
+            return None
+
+    if isinstance(userenv_map, dict) and arch:
+        if arch in userenv_map:
+            return userenv_map[arch]
+        else:
+            logger.error("Could not find arch %s in image-map[%s][%s][%s]" % (arch, image_role, engine_role, userenv))
+            return None
+    elif isinstance(userenv_map, str):
+        return userenv_map
+    else:
+        logger.error("Unexpected image-map format for %s / %s / %s" % (image_role, engine_role, userenv))
+        return None
 
 def get_engine_id_image(settings, role, id, userenv, arch=None):
     """
@@ -2125,7 +2132,7 @@ def get_engine_id_image(settings, role, id, userenv, arch=None):
 
     Args:
         settings (dict): the one data structure to rule then all
-        role (str): The engine's role
+        role (str): The engine's role ('client', 'server', 'profiler', 'worker', 'master')
         id (str, int): The engine's ID
         userenv (str): The engine's userenv
         arch (str): The target CPU architecture (e.g., 'x86_64', 'aarch64').
@@ -2146,8 +2153,13 @@ def get_engine_id_image(settings, role, id, userenv, arch=None):
             image_role = get_profiler(settings, id)
         case _:
             image_role = get_benchmark(settings, id)
-    if not image_role is None:
-        image = get_image(settings, image_role, userenv, arch=arch)
+    if image_role is not None:
+        bench_map = settings["misc"]["image-map"].get(image_role, {})
+        if role in bench_map:
+            engine_role = role
+        else:
+            engine_role = "all"
+        image = get_image(settings, image_role, engine_role, userenv, arch=arch)
     return image
 
 def get_profiler_userenv(settings, id):
@@ -2175,11 +2187,13 @@ def get_profiler_userenv(settings, id):
         logger.error("Could not find profiler name for id %s" % (id))
     else:
         if profiler_name in settings["misc"]["image-map"]:
-            if len(settings["misc"]["image-map"][profiler_name]) == 1:
-                for userenv in settings["misc"]["image-map"][profiler_name].keys():
+            bench_map = settings["misc"]["image-map"][profiler_name]
+            role_map = bench_map.get("all", {})
+            if len(role_map) == 1:
+                for userenv in role_map.keys():
                     return userenv
             else:
-                if len(settings["misc"]["image-map"][profiler_name]) == 0:
+                if len(role_map) == 0:
                     logger.error("Found no possible userenv for profiler %s" % (profiler_name))
                 else:
                     logger.error("Found more than one possible userenv for profiler %s" % (profiler_name))

--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -198,6 +198,7 @@ class RunState:
         self.workshop_force_builds = False
         self.bench_configs = {}
         self.bench_dirs = {}
+        self.split_benchmarks = {}
         self.benchmark_to_ids = {}
         self.ids_to_benchmark = {}
         self.endpoints = []
@@ -687,6 +688,29 @@ class RunState:
             self.run["benchmark"] += f",{benchmark_name}"
             self.bench_configs[benchmark_name] = bench_config_ref
 
+            has_client_workshop = os.path.exists(os.path.join(this_bench_dir, "client-workshop.json"))
+            has_server_workshop = os.path.exists(os.path.join(this_bench_dir, "server-workshop.json"))
+            has_plain_workshop = os.path.exists(os.path.join(this_bench_dir, "workshop.json"))
+
+            if has_client_workshop and has_server_workshop and has_plain_workshop:
+                logger.error("[ERROR] benchmark '%s' has workshop.json alongside client-workshop.json and server-workshop.json; remove workshop.json when using split workshop files", benchmark_name)
+                sys.exit(1)
+
+            if has_client_workshop and not has_server_workshop:
+                logger.error("[ERROR] benchmark '%s' has client-workshop.json but is missing server-workshop.json; both are required for split workshop builds", benchmark_name)
+                sys.exit(1)
+
+            if has_server_workshop and not has_client_workshop:
+                logger.error("[ERROR] benchmark '%s' has server-workshop.json but is missing client-workshop.json; both are required for split workshop builds", benchmark_name)
+                sys.exit(1)
+
+            if has_client_workshop and has_server_workshop:
+                logger.info("Benchmark '%s' has split workshop files (client-workshop.json + server-workshop.json)", benchmark_name)
+                self.split_benchmarks[benchmark_name] = {
+                    "client": f"{benchmark_name}::client",
+                    "server": f"{benchmark_name}::server",
+                }
+
             param_sets, err = load_json_file(params_files[count])
             if param_sets is None:
                 logger.error("Could not open the bench params file: %s", params_files[count])
@@ -962,7 +986,11 @@ class RunState:
             for userenv in endpoint.get("userenvs", []):
                 for arch in endpoint.get("archs", [self.arch]):
                     for bench_name in self.bench_configs:
-                        self.image_ids.setdefault(arch, {}).setdefault(bench_name, {})[userenv] = {"image": ""}
+                        if bench_name in self.split_benchmarks:
+                            for role_key in self.split_benchmarks[bench_name].values():
+                                self.image_ids.setdefault(arch, {}).setdefault(role_key, {})[userenv] = {"image": ""}
+                        else:
+                            self.image_ids.setdefault(arch, {}).setdefault(bench_name, {})[userenv] = {"image": ""}
 
         if len(self.bench_configs) == 1:
             bench_name = list(self.bench_configs.keys())[0]
@@ -1474,7 +1502,12 @@ class RunState:
                     dedup_image_ids.setdefault(tool_name, {})[userenv] = self.image_ids[arch][tid][userenv]
 
         for bench in self.bench_dirs:
-            if bench not in dedup_bench_dirs and not any(t["tool-id"] == bench for t in self.tools_params):
+            if any(t["tool-id"] == bench for t in self.tools_params):
+                continue
+            if bench in self.split_benchmarks:
+                for role_key in self.split_benchmarks[bench].values():
+                    dedup_bench_dirs[role_key] = self.bench_dirs[bench]
+            elif bench not in dedup_bench_dirs:
                 dedup_bench_dirs[bench] = self.bench_dirs[bench]
 
         utility_dirs = {}
@@ -1741,11 +1774,18 @@ class RunState:
 
             if "userenvs" in endpoint:
                 endpoint_archs = endpoint.get("archs", [self.arch])
-                for userenv in endpoint["userenvs"]:
-                    for arch in endpoint_archs:
-                        if arch not in self.image_ids:
+
+                for arch in endpoint_archs:
+                    if arch not in self.image_ids:
+                        continue
+                    for bench_or_tool in self.image_ids[arch]:
+                        if "::" in bench_or_tool:
+                            bench_name, engine_role = bench_or_tool.split("::", 1)
+                            for avail_userenv in self.image_ids[arch][bench_or_tool]:
+                                image = self.image_ids[arch][bench_or_tool][avail_userenv]["image"]
+                                endpoint_image_opt += f",{bench_name}::{engine_role}::{avail_userenv}::{arch}::{image}"
                             continue
-                        for bench_or_tool in self.image_ids[arch]:
+                        for userenv in endpoint["userenvs"]:
                             chosen_userenv = userenv
                             idx = find_index(self.tools_params, "tool-id", bench_or_tool)
                             if idx > -1:
@@ -1755,7 +1795,7 @@ class RunState:
                                              arch, bench_or_tool, chosen_userenv)
                                 sys.exit(1)
                             image = self.image_ids[arch][bench_or_tool][chosen_userenv]["image"]
-                            endpoint_image_opt += f",{bench_or_tool}::{chosen_userenv}::{arch}::{image}"
+                            endpoint_image_opt += f",{bench_or_tool}::all::{chosen_userenv}::{arch}::{image}"
                 if endpoint_image_opt:
                     endpoint_image_opt = f" --image={endpoint_image_opt.lstrip(',')}"
 

--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -241,6 +241,13 @@ class RunState:
         logger.info("Caught a CTRL-C/SIGINT, aborting via roadblock!")
         self.abort_via_roadblock = True
 
+    def _role_has_engines(self, role, bench_name):
+        """Check if any engines of the given role are assigned to this benchmark."""
+        for engine_id in self.clients_servers.get(role, {}):
+            if self.ids_to_benchmark.get(str(engine_id)) == bench_name:
+                return True
+        return False
+
 
     # ----------------------------------------------------------------
     # Phase 1: CLI and URL parsing
@@ -1014,6 +1021,14 @@ class RunState:
 
         self.assign_bench_ids()
 
+        for bench_name in self.split_benchmarks:
+            for role in list(self.split_benchmarks[bench_name].keys()):
+                if not self._role_has_engines(role, bench_name):
+                    role_key = self.split_benchmarks[bench_name].pop(role)
+                    for arch in list(self.image_ids.keys()):
+                        self.image_ids[arch].pop(role_key, None)
+                    logger.info("Skipping %s image for benchmark '%s' (no %s engines in this run)", role, bench_name, role)
+
         min_id = None
         max_id = None
         for cs_type in ("client", "server"):
@@ -1491,6 +1506,8 @@ class RunState:
         dedup_image_ids = {}
         for arch in self.image_ids:
             for tid in list(self.image_ids[arch].keys()):
+                if "::" in tid:
+                    continue
                 tool_name = tid
                 for tool_entry in self.tools_params:
                     if tool_entry["tool-id"] == tid:
@@ -1507,6 +1524,10 @@ class RunState:
             if bench in self.split_benchmarks:
                 for role_key in self.split_benchmarks[bench].values():
                     dedup_bench_dirs[role_key] = self.bench_dirs[bench]
+                    for arch in self.image_ids:
+                        if role_key in self.image_ids[arch]:
+                            for userenv in self.image_ids[arch][role_key]:
+                                dedup_image_ids.setdefault(role_key, {})[userenv] = self.image_ids[arch][role_key][userenv]
             elif bench not in dedup_bench_dirs:
                 dedup_bench_dirs[bench] = self.bench_dirs[bench]
 

--- a/rickshaw-source-images-client.py
+++ b/rickshaw-source-images-client.py
@@ -106,6 +106,34 @@ def _collect_directory(dir_path):
     return {"name": base_name, "files": files}
 
 
+def _remap_workshop_for_role(collected, role):
+    """Remap a collected directory for a role-specific workshop build.
+
+    For split workshop benchmarks (client-workshop.json + server-workshop.json),
+    rename {role}-workshop.json to workshop.json and exclude the other role's
+    workshop file so the source-images-service sees a standard workshop.json.
+    """
+    role_filename = f"{role}-workshop.json"
+    other_roles = {"client", "server"} - {role}
+    exclude_filenames = {f"{r}-workshop.json" for r in other_roles} | {"workshop.json"}
+
+    remapped_files = []
+    for entry in collected["files"]:
+        if entry["filename"] in exclude_filenames:
+            continue
+        if entry["filename"] == role_filename:
+            remapped_files.append({
+                "filename": "workshop.json",
+                "content_base64": entry["content_base64"],
+                "mode": entry["mode"],
+            })
+        else:
+            remapped_files.append(entry)
+
+    remapped_files.sort(key=lambda f: f["filename"])
+    return {"name": collected["name"], "files": remapped_files}
+
+
 # ---------------------------------------------------------------------------
 # HTTP helpers (stdlib only — no external deps)
 # ---------------------------------------------------------------------------
@@ -279,7 +307,12 @@ def _build_api_request(input_data):
     api_bench_dirs = {}
     for bench_name, bench_path in bench_dirs_input.items():
         if os.path.isdir(bench_path):
-            api_bench_dirs[bench_name] = _collect_directory(bench_path)
+            collected = _collect_directory(bench_path)
+            if "::" in bench_name:
+                role = bench_name.split("::", 1)[1]
+                collected = _remap_workshop_for_role(collected, role)
+                collected["name"] = bench_name
+            api_bench_dirs[bench_name] = collected
             logger.debug("Collected bench dir '%s': %d files",
                         bench_name, len(api_bench_dirs[bench_name]["files"]))
         else:


### PR DESCRIPTION
## Summary
- Benchmarks with fundamentally different client and server requirements can now use separate `client-workshop.json` and `server-workshop.json` files instead of a single `workshop.json`
- File presence in the benchmark repo determines behavior: single `workshop.json` = current behavior, split files = separate builds per role, both present = error
- The `--image` format gains a role field (`bench::role::userenv::arch::image`) where role is `all` for standard benchmarks or `client`/`server` for split ones
- Unused roles (e.g., optional server not present in run) are automatically pruned from image sourcing

## Jira
[PERFNFV-174](https://redhat.atlassian.net/browse/PERFNFV-174)

## Changed files
- **rickshaw-run.py** — detect split workshop files, create role-qualified image_ids entries, prune unused roles, emit new `--image` format with role field
- **rickshaw-source-images-client.py** — remap `{role}-workshop.json` → `workshop.json` in the base64 payload for role-qualified bench dirs so the SIS sees a standard `workshop.json`
- **endpoints/endpoints.py** — parse new 5/6 field `--image` format, add role dimension to image_map, role-aware image lookup in `get_engine_id_image()` and `get_profiler_userenv()`
- **endpoints/base** — update Bash `--image` parser for new field layout (used by OSP endpoint)

## Backward compatibility
- Benchmarks without split files work unchanged (`role=all`)
- No changes to workshop.json schema, workshop builder, or source-images-service
- No changes to rickshaw.json benchmark schema

## Test plan
- [ ] Run a non-split benchmark (uperf, fio) — verify no behavioral change
- [ ] Run trafficgen with split workshop files — verify client gets correct image
- [ ] Run trafficgen client-only (no server) — verify server image is skipped
- [ ] Run trafficgen with server — verify both images are sourced and assigned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)