### PR TITLE
feat: create postprocess/ directory for post-processing artifacts

### DIFF
--- a/rickshaw-gen-docs.py
+++ b/rickshaw-gen-docs.py
@@ -396,21 +396,25 @@ def main():
                     tool_dir_path = os.path.join(engine_dir, tool)
                     if not os.path.isdir(tool_dir_path):
                         continue
+                    pp_dir = os.path.join(tool_dir_path, "postprocess")
                     processed = set()
-                    for tf in sorted(os.listdir(tool_dir_path)):
-                        m_file = re.match(r'(metric-data-\S+)\.json', tf)
-                        if m_file:
-                            tool_file = m_file.group(1)
-                            if tool_file in processed:
-                                continue
-                            processed.add(tool_file)
-                            logger.debug("Working on tool_file: %s", tool_file)
-                            jobs.append({
-                                "tool_dir": tool_dir_path,
-                                "tool_file": tool_file,
-                                "collector": collector,
-                                "engine": engine,
-                            })
+                    for scan_dir in [pp_dir, tool_dir_path]:
+                        if not os.path.isdir(scan_dir):
+                            continue
+                        for tf in sorted(os.listdir(scan_dir)):
+                            m_file = re.match(r'(metric-data-\S+)\.json', tf)
+                            if m_file:
+                                tool_file = m_file.group(1)
+                                if tool_file in processed:
+                                    continue
+                                processed.add(tool_file)
+                                logger.debug("Working on tool_file: %s", tool_file)
+                                jobs.append({
+                                    "tool_dir": scan_dir,
+                                    "tool_file": tool_file,
+                                    "collector": collector,
+                                    "engine": engine,
+                                })
 
         logger.info("Launching up to %d jobs", args.max_jobs)
 
@@ -520,10 +524,15 @@ def main():
                         if not re.match(r'^\d+$', cs_id_str):
                             continue
                         cs_id_dir = os.path.join(cs_name_dir, cs_id_str)
-                        data_file = os.path.join(cs_id_dir, "post-process-data.json")
-                        data, _ = load_json_file(data_file)
-                        if data is None:
-                            data, _ = load_json_file(data_file + ".xz", uselzma=True)
+                        pp_dir = os.path.join(cs_id_dir, "postprocess")
+                        data = None
+                        for search_dir in [pp_dir, cs_id_dir]:
+                            data_file = os.path.join(search_dir, "post-process-data.json")
+                            data, _ = load_json_file(data_file)
+                            if data is None:
+                                data, _ = load_json_file(data_file + ".xz", uselzma=True)
+                            if data is not None:
+                                break
                         if data is None:
                             if cs_name == "client":
                                 logger.error("Could not open client post-process-data.json: %s", cs_id_dir)
@@ -571,7 +580,13 @@ def main():
                             )
 
                             for metric_file_prefix in period_data.get("metric-files", []):
-                                metric_dir = os.path.join(run_dir, this_samp_dir, cs_name, cs_id_str)
+                                base_dir = os.path.join(run_dir, this_samp_dir, cs_name, cs_id_str)
+                                pp_metric_dir = os.path.join(base_dir, "postprocess")
+                                metric_json = os.path.join(pp_metric_dir, metric_file_prefix + ".json")
+                                if os.path.exists(metric_json) or os.path.exists(metric_json + ".xz"):
+                                    metric_dir = pp_metric_dir
+                                else:
+                                    metric_dir = base_dir
                                 ndjson_chunk, _, pm_found, this_begin, this_end = generate_metrics(
                                     cdm, result, metric_dir, metric_file_prefix,
                                     cs_name, cs_id_str, base_metric_doc,

--- a/rickshaw-post-process-bench.py
+++ b/rickshaw-post-process-bench.py
@@ -3,6 +3,7 @@
 # vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=python
 
 import argparse
+import glob
 import json
 import os
 import re
@@ -213,11 +214,21 @@ def main():
 
             if jobs:
                 def run_bench_pp(job):
+                    pp_dir = os.path.join(job['cs_id_path'], "postprocess")
+                    if os.path.exists(pp_dir):
+                        shutil.rmtree(pp_dir)
+                    os.makedirs(pp_dir)
+                    for stale in glob.glob(os.path.join(job['cs_id_path'], "metric-data-*")):
+                        os.remove(stale)
+                    for stale_name in ["post-process-data.json", "post-process-output.txt"]:
+                        stale_path = os.path.join(job['cs_id_path'], stale_name)
+                        if os.path.exists(stale_path):
+                            os.remove(stale_path)
                     full_cmd = (
                         f"cd {job['cs_id_path']} && "
                         f"RS_CS_LABEL={job['cs_name']}-{job['cs_id']} "
                         f"{job['pp_cmd']} {job['iter_params']} "
-                        f">post-process-output.txt 2>&1"
+                        f">postprocess/post-process-output.txt 2>&1"
                     )
                     logger.debug("Running: %s", full_cmd)
                     _, output, rc = run_cmd(full_cmd)

--- a/rickshaw-post-process-tools.py
+++ b/rickshaw-post-process-tools.py
@@ -3,8 +3,10 @@
 # vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=python
 
 import argparse
+import glob
 import os
 import re
+import shutil
 import sys
 from pathlib import Path
 
@@ -149,7 +151,16 @@ def main():
     logger.info("Will run a maximum of %d post-processing jobs at a time", max_workers)
 
     def run_post_process(job):
-        cmd = f"cd {job['tool_dir']} && {job['pp_cmd']} >post-process-output.txt 2>&1"
+        pp_dir = os.path.join(job['tool_dir'], "postprocess")
+        if os.path.exists(pp_dir):
+            shutil.rmtree(pp_dir)
+        os.makedirs(pp_dir)
+        for stale in glob.glob(os.path.join(job['tool_dir'], "metric-data-*")):
+            os.remove(stale)
+        stale_output = os.path.join(job['tool_dir'], "post-process-output.txt")
+        if os.path.exists(stale_output):
+            os.remove(stale_output)
+        cmd = f"cd {job['tool_dir']} && {job['pp_cmd']} >postprocess/post-process-output.txt 2>&1"
         _, output, rc = run_cmd(cmd)
         return rc
 


### PR DESCRIPTION
## Summary
- Post-processing orchestration now creates a `postprocess/` subdirectory inside each sample/tool directory and cleans it on re-run (`rm -rf` + `mkdir`)
- Output redirection writes `post-process-output.txt` into `postprocess/`
- `rickshaw-gen-docs.py` checks `postprocess/` first for metric-data and post-process-data.json files, falling back to the directory root for backward compatibility with runs processed before this change

## Jira
[PERFNFV-316](https://redhat.atlassian.net/browse/PERFNFV-316)

## Related
- toolbox PR #117 (CDMMetrics output_dir change)

## Test plan
- [ ] Run a benchmark — verify `postprocess/` directory is created with artifacts inside
- [ ] Re-run `crucible postprocess` — verify directory is cleaned and recreated
- [ ] Verify old runs (without `postprocess/`) still index correctly via gen-docs fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)