### PR TITLE
feat: propagate --log-level to all rickshaw scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,10 @@ For the kube endpoint, the `arch` setting in `schema/kube.json` lets users targe
 
 The source-images-service validates that `request.arch` matches `platform.machine()` at the start of each job, preventing architecture mismatches from producing incorrectly-tagged images. The `/api/v1/health` endpoint reports the service's native architecture.
 
+## Log Level Propagation
+
+All rickshaw scripts accept `--log-level` with a standard vocabulary: `normal`, `verbose`, `debug`, `verbose-debug`. When `crucible run --log-level <level>` is invoked with a non-default level, `rickshaw-run.py` overrides the `endpoints.log-level` and `roadblock.log-level` values from `rickshaw-settings.json` and updates the settings dict before saving it, so engine scripts also pick up the override via the saved settings file. The `verbose-debug` level enables roadblock's ultra-verbose mode end-to-end (controller, endpoints, and engine-side roadblock invocations).
+
 ## CI
 
 GitHub Actions workflows in `.github/workflows/`:

--- a/endpoints/endpoints.py
+++ b/endpoints/endpoints.py
@@ -976,7 +976,7 @@ def setup_logger(log_level):
     logging_handler.setFormatter(log_format)
 
     match log_level:
-        case "debug":
+        case "debug" | "verbose":
             logging_handler.setLevel(logging.DEBUG)
         case "verbose-debug":
             logging_handler.setLevel(VERBOSE_DEBUG_LEVEL)
@@ -1731,7 +1731,7 @@ def process_options():
                         help = "Allow the user to control the degree of verbosity of the output.",
                         required = False,
                         type = str,
-                        choices = [ "debug", "normal", "verbose-debug" ],
+                        choices = [ "debug", "normal", "verbose", "verbose-debug" ],
                         default = "normal")
 
     parser.add_argument("--max-sample-failures",

--- a/rickshaw-gen-docs.py
+++ b/rickshaw-gen-docs.py
@@ -309,7 +309,7 @@ def main():
     parser.add_argument("--base-run-dir", required=True)
     parser.add_argument("--max-jobs", type=int, default=32)
     parser.add_argument("--ver", default="v9dev", choices=SUPPORTED_CDM_VERS)
-    parser.add_argument("--log-level", default="normal", choices=["normal", "debug"])
+    parser.add_argument("--log-level", default="normal", choices=["normal", "verbose", "debug", "verbose-debug"])
     args = parser.parse_args()
 
     logger = setup_logging("rickshaw-gen-docs", args.log_level)

--- a/rickshaw-post-process-bench.py
+++ b/rickshaw-post-process-bench.py
@@ -78,7 +78,7 @@ def main():
     parser.add_argument("--base-run-dir", required=True,
                         help="Directory where result data is located")
     parser.add_argument("--log-level", default="normal",
-                        choices=["normal", "debug"],
+                        choices=["normal", "verbose", "debug", "verbose-debug"],
                         help="Logging verbosity")
     args = parser.parse_args()
 

--- a/rickshaw-post-process-tools.py
+++ b/rickshaw-post-process-tools.py
@@ -32,7 +32,7 @@ def main():
     parser.add_argument("--base-run-dir", required=True,
                         help="Directory where result data is located")
     parser.add_argument("--log-level", default="normal",
-                        choices=["normal", "debug"],
+                        choices=["normal", "verbose", "debug", "verbose-debug"],
                         help="Logging verbosity")
     args = parser.parse_args()
 

--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -160,6 +160,7 @@ class RunState:
             "roadblock-password": "flubber",
         }
 
+        self.log_level = "normal"
         self.rickshaw_project_dir = str(Path(__file__).resolve().parent)
         self.bench_schema_file = os.path.join(self.rickshaw_project_dir, "schema", "benchmark.json")
         self.tool_schema_file = os.path.join(self.rickshaw_project_dir, "schema", "tool.json")
@@ -1463,6 +1464,7 @@ class RunState:
             f" --input {source_input_file}"
             f" --output {source_output_file}"
             f" --service-url {service_url}"
+            f" --log-level {self.log_level}"
         )
         logger.info("Running (%s): %s", arch, source_images_cmd)
         if len(self.required_archs) > 1:
@@ -2203,12 +2205,16 @@ class RunState:
 
 def main():
     global logger
+    valid_log_levels = ("normal", "verbose", "debug", "verbose-debug")
     log_level = "normal"
     for i, arg in enumerate(sys.argv[1:]):
         if arg == "--log-level" and i + 2 < len(sys.argv):
             log_level = sys.argv[i + 2]
         elif arg.startswith("--log-level="):
             log_level = arg.split("=", 1)[1]
+    if log_level not in valid_log_levels:
+        print(f"Invalid --log-level value '{log_level}'. Must be one of: {', '.join(valid_log_levels)}", file=sys.stderr)
+        sys.exit(1)
     logger = setup_logging("rickshaw-run", log_level)
     # At normal level, suppress library INFO (e.g. roadblock) for curated
     # output. Raise the root logger to WARNING while keeping our own logger
@@ -2219,6 +2225,7 @@ def main():
     logger.info("rickshaw-run.py starting")
 
     state = RunState()
+    state.log_level = log_level
     logger.info("Found %d available cpus, arch=%s", state.available_cpus, state.arch)
 
     for e in ("RS_NAME", "RS_EMAIL", "RS_TAGS", "RS_DESC"):
@@ -2229,6 +2236,18 @@ def main():
 
     state.process_cmdline()
     state.load_settings_info()
+    if state.log_level != "normal":
+        # Map CLI vocabulary to component vocabulary. Endpoints and
+        # roadblock accept normal/debug/verbose-debug but not verbose.
+        settings_level_map = {"verbose": "debug", "debug": "debug", "verbose-debug": "verbose-debug"}
+        settings_level = settings_level_map.get(state.log_level, state.log_level)
+        logger.info("CLI --log-level=%s overriding settings: endpoints=%s->%s, roadblock=%s->%s",
+                     state.log_level, state.endpoint_log_level, settings_level,
+                     state.rb_log_level, settings_level)
+        state.endpoint_log_level = state.log_level
+        state.rb_log_level = settings_level
+        state.jsonsettings["roadblock"]["log-level"] = settings_level
+        state.jsonsettings["endpoints"]["log-level"] = state.log_level
     state.load_bench_params()
     state.validate_controller_env()
     state.make_run_dirs()

--- a/rickshaw-source-images-client.py
+++ b/rickshaw-source-images-client.py
@@ -34,12 +34,8 @@ else:
         exit(2)
     sys.path.append(str(p))
 from toolbox.json import validate_schema
+from toolbox.logging import setup_logging
 
-# ---------------------------------------------------------------------------
-# Logging
-# ---------------------------------------------------------------------------
-
-LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
 logger = logging.getLogger("rickshaw-source-images-client")
 
 # ---------------------------------------------------------------------------
@@ -665,18 +661,13 @@ def main():
                         help="Path to write output JSON")
     parser.add_argument("--service-url", required=True,
                         help="Base URL of the source-images service")
-    parser.add_argument("--log-level", default="info",
-                        choices=["debug", "info", "warning", "error"],
-                        help="Logging level (default: info)")
+    parser.add_argument("--log-level", default="normal",
+                        choices=["normal", "verbose", "debug", "verbose-debug"],
+                        help="Logging level (default: normal)")
     args = parser.parse_args()
 
     # Configure logging
-    level = getattr(logging, args.log_level.upper(), logging.INFO)
-    if level == logging.DEBUG:
-        log_format = LOG_FORMAT
-    else:
-        log_format = "%(message)s"
-    logging.basicConfig(level=level, format=log_format, stream=sys.stderr)
+    setup_logging("rickshaw-source-images-client", args.log_level)
 
     # 1. Read input JSON
     input_path = _resolve_json_path(args.input)
@@ -704,8 +695,9 @@ def main():
     logger.debug("Building API request from input JSON")
     api_request = _build_api_request(input_data)
 
-    # Pass through the log level to the service
-    api_request["log-level"] = args.log_level
+    # Map to service vocabulary before sending
+    api_level_map = {"normal": "info", "verbose": "debug", "debug": "debug", "verbose-debug": "debug"}
+    api_request["log-level"] = api_level_map.get(args.log_level, "info")
 
     # 4. Submit job
     job_id = _submit_job(args.service_url, api_request)

--- a/schema/rickshaw-settings.json
+++ b/schema/rickshaw-settings.json
@@ -29,6 +29,7 @@
                     "enum": [
                         "debug",
                         "normal",
+                        "verbose",
                         "verbose-debug"
                     ],
                     "default": "normal"


### PR DESCRIPTION
## Summary
- Store CLI `--log-level` on `RunState` and propagate to all scripts invoked during a run
- When non-default, override endpoint and roadblock log levels from `rickshaw-settings.json` and update the settings dict so engine-side roadblock invocations also pick up the override via the saved settings file
- Standardize the log level vocabulary to four levels (`normal`, `verbose`, `debug`, `verbose-debug`) across all scripts
- Add `verbose` to endpoint argparse choices and `setup_logger()`
- Switch `rickshaw-source-images-client.py` from `logging.basicConfig()` to toolbox `setup_logging()` with a mapping at the source-images-service API boundary
- Add `verbose` to the endpoints log-level enum in `rickshaw-settings.json` schema (roadblock enum unchanged since roadblock doesn't accept `verbose`)
- Map `verbose` → `debug` for roadblock since roadblock only accepts `normal`/`debug`/`verbose-debug`
- Part of [PERFNFV-323](https://redhat.atlassian.net/browse/PERFNFV-323)

## Test plan
- [ ] `crucible run --log-level debug <run-file>` — debug output from all scripts
- [ ] `crucible run --log-level verbose <run-file>` — verbose output, engines use debug-level roadblock
- [ ] `crucible run <run-file>` (no flag) — default behavior unchanged
- [ ] Verify saved `rickshaw-settings.json` in run config dir reflects CLI override

🤖 Generated with [Claude Code](https://claude.com/claude-code)