### PR TITLE
fix: replace flat userenv validation lines with role-qualified engine-userenv

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -386,6 +386,7 @@ function set_osruntime_numanode_cpupart() {
 # accepts optional arguments listing endpoint specific engine types
 function echo_clients_servers() {
     local engine_types=""
+    local id
 
     if [ $num_clients -gt 0 ]; then
         engine_types+="client "
@@ -398,6 +399,13 @@ function echo_clients_servers() {
     if [ $num_profilers -gt 0 ]; then
         echo "profiler ${!profilers[@]}"
     fi
+
+    for id in ${!clients[@]}; do
+        echo "engine-userenv client ${id} ${userenv}"
+    done
+    for id in ${!servers[@]}; do
+        echo "engine-userenv server ${id} ${userenv}"
+    done
 
     engine_types+="$@"
 

--- a/endpoints/kube/kube.py
+++ b/endpoints/kube/kube.py
@@ -525,16 +525,12 @@ def validate():
     endpoints.validate_log("engine-types %s" % (" ".join(list(engine_types))))
 
     engines = dict()
-    userenvs = []
     for engine_role in endpoint_settings["engines"]["settings"].keys():
         if not engine_role in engines:
             engines[engine_role] = []
-        
+
         for engine_id in endpoint_settings["engines"]["settings"][engine_role].keys():
             engines[engine_role].append(engine_id)
-
-            if not endpoint_settings["engines"]["settings"][engine_role][engine_id]["userenv"] in userenvs:
-                userenvs.append(endpoint_settings["engines"]["settings"][engine_role][engine_id]["userenv"])
 
     endpoints.validate_comment("engines: %s" % (engines))
     for engine_role in engines.keys():
@@ -553,9 +549,10 @@ def validate():
             if not found_engine:
                 endpoints.validate_error("Could not find a benchmark mapping for engine ID %d" % (engine_id))
 
-    endpoints.validate_comment("userenvs: %s" % (userenvs))
-    for userenv in userenvs:
-        endpoints.validate_log("userenv %s" % (userenv))
+    for engine_role in endpoint_settings["engines"]["settings"].keys():
+        for engine_id in endpoint_settings["engines"]["settings"][engine_role].keys():
+            userenv = endpoint_settings["engines"]["settings"][engine_role][engine_id]["userenv"]
+            endpoints.validate_log("engine-userenv %s %s %s" % (engine_role, engine_id, userenv))
 
     debug_output = False
     if args.log_level == "debug":

--- a/endpoints/osp/osp
+++ b/endpoints/osp/osp
@@ -134,10 +134,9 @@ function osp_req_check() {
     if [ $rc -gt 0 ]; then
         exit_error "Could not run 'openstack' on overcloud host: $osp_cmd"
     fi
-    # Validation returns what clients and servers would be used and the userenv
+    # Validation returns what clients and servers would be used
     if [ "$do_validate" == 1 ]; then
         echo_clients_servers "profiler" "compute"
-        echo "userenv $userenv"
         exit
     fi
 }

--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -132,7 +132,6 @@ def validate():
     endpoints.validate_log("engine-types %s" % (" ".join(list(engine_types))))
 
     engines = dict()
-    userenvs = []
     for remote in endpoint_settings["remotes"]:
         for engine in remote["engines"]:
             if engine["role"] == "profiler":
@@ -140,9 +139,6 @@ def validate():
             if not engine["role"] in engines:
                 engines[engine["role"]] = []
             engines[engine["role"]].extend(engine["ids"])
-
-        if not remote["config"]["settings"]["userenv"] in userenvs:
-            userenvs.append(remote["config"]["settings"]["userenv"])
 
     endpoints.validate_comment("engines: %s" % (engines))
     for role in engines.keys():
@@ -158,9 +154,13 @@ def validate():
             if not found_engine:
                 endpoints.validate_error("Could not find a benchmark mapping for engine ID %d" % (engine_id))
 
-    endpoints.validate_comment("userenvs: %s" % (userenvs))
-    for userenv in userenvs:
-        endpoints.validate_log("userenv %s" % (userenv))
+    for remote in endpoint_settings["remotes"]:
+        userenv = remote["config"]["settings"]["userenv"]
+        for engine in remote["engines"]:
+            if engine["role"] == "profiler":
+                continue
+            for eid in engine["ids"]:
+                endpoints.validate_log("engine-userenv %s %d %s" % (engine["role"], eid, userenv))
 
     remotes = dict()
     for remote in endpoint_settings["remotes"]:

--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -926,8 +926,6 @@ class RunState:
             with open(os.path.join(validation_dir, f"{endpoint['label']}.txt"), "w") as f:
                 f.write(output)
 
-            endpoint["userenvs"] = []
-
             for line in output.split("\n"):
                 line = line.strip()
                 if not line or line.startswith("#"):
@@ -972,16 +970,21 @@ class RunState:
                     logger.debug("endpoint %s reports architectures: %s",
                                  endpoint["label"], endpoint["archs"])
 
-                elif keyword == "userenv":
-                    userenv = parts[1] if len(parts) > 1 else ""
-                    endpoint["userenvs"].append(userenv)
-                    logger.debug("clients/servers for endpoint %s will have userenv %s",
-                                 endpoint["label"], userenv)
+                elif keyword == "engine-userenv":
+                    role = parts[1]
+                    eid = parts[2]
+                    userenv = parts[3]
+                    endpoint.setdefault("engine-userenvs", {}).setdefault(role, {})[eid] = userenv
 
                 else:
                     logger.error("[ERROR] output from endpoint validation incorrect for %s:\n%s",
                                  endpoint["label"], line)
                     sys.exit(1)
+
+            endpoint["userenvs"] = list(set(
+                ue for role_map in endpoint.get("engine-userenvs", {}).values()
+                for ue in role_map.values()
+            ))
 
         for endpoint in self.endpoints:
             if "archs" in endpoint:
@@ -989,16 +992,6 @@ class RunState:
         if not self.required_archs:
             self.required_archs.add(self.arch)
         logger.info("Required architectures across all endpoints: %s", sorted(self.required_archs))
-
-        for endpoint in self.endpoints:
-            for userenv in endpoint.get("userenvs", []):
-                for arch in endpoint.get("archs", [self.arch]):
-                    for bench_name in self.bench_configs:
-                        if bench_name in self.split_benchmarks:
-                            for role_key in self.split_benchmarks[bench_name].values():
-                                self.image_ids.setdefault(arch, {}).setdefault(role_key, {})[userenv] = {"image": ""}
-                        else:
-                            self.image_ids.setdefault(arch, {}).setdefault(bench_name, {})[userenv] = {"image": ""}
 
         if len(self.bench_configs) == 1:
             bench_name = list(self.bench_configs.keys())[0]
@@ -1021,6 +1014,33 @@ class RunState:
                 self.run["bench-ids"] = f"{bench_name}:{'+'.join(id_ranges)}"
 
         self.assign_bench_ids()
+
+        for endpoint in self.endpoints:
+            engine_userenvs = endpoint.get("engine-userenvs", {})
+            for arch in endpoint.get("archs", [self.arch]):
+                for bench_name in self.bench_configs:
+                    if bench_name in self.split_benchmarks:
+                        for role, role_key in self.split_benchmarks[bench_name].items():
+                            if engine_userenvs:
+                                role_userenvs = set()
+                                for eid, ue in engine_userenvs.get(role, {}).items():
+                                    if self.ids_to_benchmark.get(str(eid)) == bench_name:
+                                        role_userenvs.add(ue)
+                            else:
+                                role_userenvs = endpoint.get("userenvs", [])
+                            for userenv in role_userenvs:
+                                self.image_ids.setdefault(arch, {}).setdefault(role_key, {})[userenv] = {"image": ""}
+                    else:
+                        if engine_userenvs:
+                            bench_userenvs = set()
+                            for role in ("client", "server"):
+                                for eid, ue in engine_userenvs.get(role, {}).items():
+                                    if self.ids_to_benchmark.get(str(eid)) == bench_name:
+                                        bench_userenvs.add(ue)
+                        else:
+                            bench_userenvs = endpoint.get("userenvs", [])
+                        for userenv in bench_userenvs:
+                            self.image_ids.setdefault(arch, {}).setdefault(bench_name, {})[userenv] = {"image": ""}
 
         for bench_name in self.split_benchmarks:
             for role in list(self.split_benchmarks[bench_name].keys()):


### PR DESCRIPTION
## Summary
- Endpoints now emit `engine-userenv <role> <id> <userenv>` instead of flat `userenv <name>` lines during validation
- `rickshaw-run.py` uses the engine ID to cross-reference `ids_to_benchmark` and build `image_ids` with role+benchmark awareness
- Split benchmarks (trafficgen) with different userenvs per role no longer fail at image sourcing due to cross-product requests
- All three endpoint types updated: remotehosts, kube, osp (via `echo_clients_servers` in base)

Closes: [PERFNFV-329](https://redhat.atlassian.net/browse/PERFNFV-329)

## Test plan
- [ ] Run trafficgen with different userenvs per role (client alma8, server rhel10.2) — verify only `trafficgen::client/alma8` and `trafficgen::server/rhel10.2` are requested
- [ ] Run with same userenv on both roles — verify no regression
- [ ] Run non-split benchmark (uperf) with different userenvs — verify both userenvs requested under single `uperf` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)