### PR TITLE
feat: add ssh-key-algorithm and ssh-key-bits run-params for FIPS compliance

### DIFF
--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -297,7 +297,7 @@ class RunState:
                 r'run-id|id|bench-params|tool-params|'
                 r'test-order|tool-group|num-samples|max-sample-failures|name|bench-ids|'
                 r'registries-json|external-userenvs-dir|'
-                r'email|desc)$', arg
+                r'email|desc|ssh-key-algorithm|ssh-key-bits)$', arg
             ):
                 logger.debug("argument: [%s]", arg)
                 self.run[arg] = val

--- a/schema/rickshaw-run.json
+++ b/schema/rickshaw-run.json
@@ -157,6 +157,14 @@
       "description": "The source URL for pulling base container images used in engine image builds.",
       "type": "string"
     },
+    "ssh-key-algorithm": {
+      "description": "The SSH key algorithm for the per-run engine key.",
+      "type": "string"
+    },
+    "ssh-key-bits": {
+      "description": "The key size in bits for the per-run SSH key.",
+      "type": "integer"
+    },
     "tool-group": {
       "description": "An identifier grouping related tool configurations together.",
       "type": "string",

--- a/schema/run-file.json
+++ b/schema/run-file.json
@@ -74,6 +74,21 @@
 		    "description": "Override the user email for this run. If specified, name must also be provided.",
 		    "type": "string",
 		    "minLength": 1
+		},
+		"ssh-key-algorithm": {
+		    "description": "The SSH key algorithm for the per-run engine key. Ed25519 is the default but is not permitted in FIPS-compliant environments; use ecdsa or rsa instead.",
+		    "type": "string",
+		    "enum": [
+			"ecdsa",
+			"ed25519",
+			"rsa"
+		    ],
+		    "default": "ed25519"
+		},
+		"ssh-key-bits": {
+		    "description": "The key size in bits for RSA or ECDSA keys. Cannot be used with ed25519 (fixed key size). RSA: minimum 1024, common values 2048/3072/4096. ECDSA: must be 256, 384, or 521 (selecting the elliptic curve).",
+		    "type": "integer",
+		    "minimum": 256
 		}
 	    },
 	    "dependentRequired": {


### PR DESCRIPTION
## Summary
- Adds `ssh-key-algorithm` (enum: ecdsa, ed25519, rsa) and `ssh-key-bits` (integer) to the run-params section of the run-file schema
- Adds both fields to rickshaw-run.json so internal settings validation accepts them
- Updates the rickshaw-run.py argument parser to recognize the forwarded CLI arguments

These schema changes support [PERFNFV-327](https://redhat.atlassian.net/browse/PERFNFV-327) — making the engine SSH key algorithm configurable for FIPS-compliant environments. The actual key generation logic that consumes these values lives in crucible's `bin/_main` (companion PR to follow).

## Test plan
- [ ] Verify run-file with `ssh-key-algorithm` and `ssh-key-bits` passes schema validation
- [ ] Verify run-file without the new fields still passes (backward compatible)
- [ ] Verify invalid algorithm values (e.g., `"dsa"`) are rejected by schema validation
- [ ] Verify blockbreaker correctly forwards the new params as CLI arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)