### PR TITLE
feat: per-instance client-server-ratio validation and engine pairing

### DIFF
--- a/endpoints/endpoints.py
+++ b/endpoints/endpoints.py
@@ -2184,6 +2184,24 @@ def get_profiler_userenv(settings, id):
 
     return None
 
+_engine_pairing_cache = None
+
+def get_engine_buddy(engine_label, settings):
+    """Look up an engine's buddy from the pairing manifest."""
+    global _engine_pairing_cache
+    if _engine_pairing_cache is None:
+        pairing_file = os.path.join(
+            settings["dirs"]["local"]["engine-conf"], "pairing.json")
+        if os.path.exists(pairing_file):
+            _engine_pairing_cache, _ = load_json_file(pairing_file)
+        if _engine_pairing_cache is None:
+            _engine_pairing_cache = {}
+    if engine_label in _engine_pairing_cache:
+        return _engine_pairing_cache[engine_label]
+    return re.sub(r"^(server|client)",
+                  lambda m: "client" if m.group(1) == "server" else "server",
+                  engine_label)
+
 def base64_encode(string):
     """
     Convert a string to base64 encoding

--- a/endpoints/kube/kube.py
+++ b/endpoints/kube/kube.py
@@ -2752,7 +2752,7 @@ def test_start(msgs_dir, test_id, tx_msgs_dir):
                     if msg["payload"]["message"]["command"] == "user-object":
                         if "svc" in msg["payload"]["message"]["user-object"] and "ports" in msg["payload"]["message"]["user-object"]["svc"]:
                             server_engine = msg["payload"]["sender"]["id"]
-                            client_engine = re.sub(r"server", r"client", server_engine)
+                            client_engine = endpoints.get_engine_buddy(server_engine, settings)
 
                             logger.info("Found a service message from server engine %s to client engine %s:\n%s" % (server_engine, client_engine, endpoints.dump_json(msg["payload"])))
 

--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -1445,7 +1445,7 @@ def test_start(msgs_dir, test_id, tx_msgs_dir):
                     if msg["payload"]["message"]["command"] == "user-object":
                         if "svc" in msg["payload"]["message"]["user-object"] and "ports" in msg["payload"]["message"]["user-object"]["svc"]:
                             server_engine = msg["payload"]["sender"]["id"]
-                            client_engine = re.sub(r"server", r"client", server_engine)
+                            client_engine = endpoints.get_engine_buddy(server_engine, settings)
 
                             logger.info("Found a service message from server engine %s to client engine %s" % (server_engine, client_engine))
 

--- a/engine/engine-script-library
+++ b/engine/engine-script-library
@@ -407,6 +407,26 @@ function get_data() {
         fi
     done 9< "$cs_files_list"
 
+    # Get the engine pairing manifest and determine buddy
+    if [ "$cs_type" == "client" -o "$cs_type" == "server" ]; then
+        scp_from_controller "$ssh_id_file" "$engine_config_dir/pairing.json" "pairing.json" abort get-data-end
+        cs_buddy=""
+        local buddy_source="ID-matching (fallback)"
+        if [ -f "pairing.json" ]; then
+            cs_buddy=$(jq -r '.["'"$cs_label"'"] // empty' "pairing.json")
+            if [ -n "$cs_buddy" ]; then
+                buddy_source="pairing manifest"
+            fi
+        fi
+        if [ -z "$cs_buddy" ]; then
+            case "${cs_type}" in
+                "client") cs_buddy="server-${cs_id}" ;;
+                "server") cs_buddy="client-${cs_id}" ;;
+            esac
+        fi
+        echo "Engine buddy: $cs_buddy (source: $buddy_source)"
+    fi
+
     # Get the benchmark and tool commands
     cs_start_bench_cmds="$cs_label-start-bench.cmds"
     # Everyone gets the bench-start-cmds (the client's start cmds) because that tells everyone how many tests there are
@@ -537,11 +557,7 @@ function prepare_roadblock_user_msgs_file {
                 echo -n "${separator}" >> "${user_msgs_file}"
                 cat "${msg_file}" >> "${user_msgs_file}"
             else
-                local buddy=""
-                case "${cs_type}" in
-                    "client") buddy="server-${cs_id}" ;;
-                    "server") buddy="client-${cs_id}" ;;
-                esac
+                local buddy="${cs_buddy}"
                 echo "  Raw payload, wrapping with targeted addressing (endpoint=${endpoint_label}, buddy=${buddy})"
                 local payload
                 payload=$(cat "${msg_file}")
@@ -638,15 +654,6 @@ function evaluate_test_roadblock {
             local cs_buddy=""
             local count=0
             local roadblock_label=$(echo "${roadblock_name}" | awk -F: '{ print $2 }')
-
-            case "${cs_type}" in
-                "client")
-                    cs_buddy="server-${cs_id}"
-                    ;;
-                "server")
-                    cs_buddy="client-${cs_id}"
-                    ;;
-            esac
 
             echo "My cs_buddy=${cs_buddy}"
 

--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -836,7 +836,7 @@ class RunState:
                         "but none are defined", label)
                     sys.exit(1)
 
-                if server_ids and ratio != "1:N":
+                if server_ids and server_required and ratio != "1:N":
                     if len(client_ids) != len(server_ids):
                         logger.error(
                             "[ERROR] benchmark '%s' has %d client(s) and "

--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -202,6 +202,7 @@ class RunState:
         self.split_benchmarks = {}
         self.benchmark_to_ids = {}
         self.ids_to_benchmark = {}
+        self.bench_instances = []
         self.endpoints = []
         self.image_ids = {}
         self.tools_configs = {}
@@ -778,6 +779,7 @@ class RunState:
             if len(parts) != 2:
                 continue
             bench, ids_str = parts
+            instance_ids = set()
             id_ranges = []
             for segment in ids_str.split(","):
                 for sub in segment.split("+"):
@@ -788,11 +790,126 @@ class RunState:
                     for i in range(int(m.group(1)), int(m.group(2)) + 1):
                         self.ids_to_benchmark[str(i)] = bench
                         self.benchmark_to_ids.setdefault(bench, []).append(str(i))
+                        instance_ids.add(str(i))
                 elif re.match(r'^\d+$', id_range):
                     self.ids_to_benchmark[id_range] = bench
                     self.benchmark_to_ids.setdefault(bench, []).append(id_range)
+                    instance_ids.add(id_range)
                 else:
                     logger.warning("ID range or number not recognized: %s", id_range)
+            if instance_ids:
+                self.bench_instances.append({"name": bench, "ids": instance_ids})
+
+    def validate_client_server_ids(self):
+        """Validate client/server ID allocation per benchmark instance."""
+        for idx, instance in enumerate(self.bench_instances):
+            bench_name = instance["name"]
+            instance_ids = instance["ids"]
+            bench_config = self.bench_configs.get(bench_name, {})
+
+            client_ids = {eid for eid in instance_ids
+                          if eid in self.clients_servers.get("client", {})}
+            server_ids = {eid for eid in instance_ids
+                          if eid in self.clients_servers.get("server", {})}
+
+            has_server_config = "server" in bench_config
+            server_required = (has_server_config
+                               and bench_config["server"].get("required", True))
+            ratio = bench_config.get("client", {}).get("client-server-ratio", "")
+
+            label = bench_name
+            name_count = sum(1 for i in self.bench_instances if i["name"] == bench_name)
+            if name_count > 1:
+                label = f"{bench_name}[{idx}]"
+
+            if not client_ids:
+                logger.error(
+                    "[ERROR] benchmark '%s' has no client engines "
+                    "(IDs %s are all server-only)",
+                    label, sorted(instance_ids, key=int))
+                sys.exit(1)
+
+            if has_server_config:
+                if server_required and not server_ids:
+                    logger.error(
+                        "[ERROR] benchmark '%s' requires server engines "
+                        "but none are defined", label)
+                    sys.exit(1)
+
+                if server_ids and ratio != "1:N":
+                    if len(client_ids) != len(server_ids):
+                        logger.error(
+                            "[ERROR] benchmark '%s' has %d client(s) and "
+                            "%d server(s); for 1:1 client-server-ratio "
+                            "these must be equal (set client-server-ratio "
+                            "to '1:N' in rickshaw.json to allow unequal "
+                            "counts)", label,
+                            len(client_ids), len(server_ids))
+                        sys.exit(1)
+            else:
+                if server_ids:
+                    logger.error(
+                        "[ERROR] benchmark '%s' does not use servers but "
+                        "server engine IDs %s are assigned to it",
+                        label, sorted(server_ids, key=int))
+                    sys.exit(1)
+
+            count_msg = f"{len(client_ids)} client(s)"
+            if server_ids:
+                count_msg += f", {len(server_ids)} server(s)"
+            if ratio:
+                count_msg += f" (client-server-ratio: {ratio})"
+            logger.info("Benchmark '%s': %s", label, count_msg)
+
+    def compute_engine_pairing(self):
+        """Compute server-client pairing per benchmark instance and write pairing.json."""
+        pairing = {}
+
+        for instance in self.bench_instances:
+            bench_name = instance["name"]
+            instance_ids = instance["ids"]
+            bench_config = self.bench_configs.get(bench_name, {})
+            ratio = bench_config.get("client", {}).get("client-server-ratio", "")
+
+            client_ids = sorted(
+                (eid for eid in instance_ids
+                 if eid in self.clients_servers.get("client", {})),
+                key=int)
+            server_ids = sorted(
+                (eid for eid in instance_ids
+                 if eid in self.clients_servers.get("server", {})),
+                key=int)
+
+            if not client_ids or not server_ids:
+                continue
+
+            if ratio == "1:N":
+                for i, sid in enumerate(server_ids):
+                    target_client = client_ids[i % len(client_ids)]
+                    pairing[f"server-{sid}"] = f"client-{target_client}"
+                for cid in client_ids:
+                    paired_servers = [sid for sid in server_ids
+                                     if pairing.get(f"server-{sid}") == f"client-{cid}"]
+                    if paired_servers:
+                        pairing[f"client-{cid}"] = f"server-{paired_servers[0]}"
+            else:
+                for cid, sid in zip(client_ids, server_ids):
+                    pairing[f"client-{cid}"] = f"server-{sid}"
+                    pairing[f"server-{sid}"] = f"client-{cid}"
+
+            ratio_label = f" (client-server-ratio: {ratio})" if ratio else ""
+            logger.info("Engine pairing for benchmark '%s'%s:", bench_name, ratio_label)
+            for cid in client_ids:
+                paired_servers = [sid for sid in server_ids
+                                  if pairing.get(f"server-{sid}") == f"client-{cid}"]
+                if paired_servers:
+                    server_list = ", ".join(f"server-{s}" for s in paired_servers)
+                    logger.info("  client-%s <-> %s", cid, server_list)
+
+        pairing_file = os.path.join(self.engine_config_dir, "pairing.json")
+        with open(pairing_file, "w") as fh:
+            json.dump(pairing, fh, indent=2, sort_keys=True)
+        logger.debug("Wrote engine pairing manifest to %s", pairing_file)
 
     def make_run_dirs(self):
         for dirtype in ("base-run-dir", "tools-dir"):
@@ -1014,6 +1131,8 @@ class RunState:
                 self.run["bench-ids"] = f"{bench_name}:{'+'.join(id_ranges)}"
 
         self.assign_bench_ids()
+        self.validate_client_server_ids()
+        self.compute_engine_pairing()
 
         for endpoint in self.endpoints:
             engine_userenvs = endpoint.get("engine-userenvs", {})


### PR DESCRIPTION
## Summary

- Port the `client-server-ratio` validation lost in the Perl→Python migration (commit befa943), validating per benchmark **entry** rather than per benchmark type to support multiple instances with different topologies
- Compute an engine pairing manifest (`pairing.json`) that maps each server to its correct client buddy, fixing 1:N scenarios where the hardcoded `server-N → client-N` buddy logic targets nonexistent clients
- Update engine-script-library, remotehosts, and kube endpoints to read the pairing manifest instead of using hardcoded ID-matching assumptions
- Log the engine pairing early in the console output and the buddy source on each engine for debugging visibility

## Test plan

- [ ] Run a standard 1:1 benchmark (uperf/fio) — verify pairing is correct and run completes normally
- [ ] Run a 1:N benchmark (trafficgen) with a single instance — verify unequal client/server counts are allowed and servers pair with the correct client
- [ ] Run multiple instances of a 1:N benchmark — verify per-instance validation and pairing
- [ ] Verify console output shows engine pairing early in the run
- [ ] Verify engine logs show buddy source (pairing manifest vs fallback)
- [ ] Verify a mismatched 1:1 config (e.g., 2 clients + 1 server) is rejected with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)