### PR TITLE
fix: remove local cs_buddy declaration that shadows pairing manifest …

### DIFF
--- a/engine/engine-script-library
+++ b/engine/engine-script-library
@@ -651,7 +651,6 @@ function evaluate_test_roadblock {
         if [ "${cs_type}" == "client" -o "${cs_type}" == "server" ]; then
             echo "Processing message file:"
 
-            local cs_buddy=""
             local count=0
             local roadblock_label=$(echo "${roadblock_name}" | awk -F: '{ print $2 }')
 


### PR DESCRIPTION
…value

The `local cs_buddy=""` declaration inside evaluate_test_roadblock() shadows the outer cs_buddy variable that was correctly set by the pairing manifest logic added in ab9f598.

With the shadowed (empty) value, the legacy broadcast message filter (Filter 2) compares sender.id against an empty string, which never matches. This silently drops all broadcast messages from the buddy engine, breaking auto-discovery for benchmarks that use recipient.type="all" messaging (e.g. trafficgen Grout L3).

Benchmarks using targeted messaging (uperf, iperf) are unaffected because their messages are delivered through Filter 1 which matches on recipient.id, independent of cs_buddy.