### PR TITLE
fix: critical bugs in endpoints, kube, engine, schemas, and base

### DIFF
--- a/endpoints/base
+++ b/endpoints/base
@@ -262,7 +262,7 @@ function process_opts() {
 }
 if [ -z "$max_sample_failures" ]; then
     max_sample_failures=3
-    if [ "do_validate" == "0" ]; then
+    if [ "$do_validate" == "0" ]; then
         echo "[WARNING] --max-sample-failures was not used, so setting to default of $max_sample_failures"
     fi
 fi
@@ -628,7 +628,7 @@ function do_roadblock() {
     fi
     if [ -n "${wait_for_log}" -a -f "${wait_for_log}" ]; then
         echo "wait-for log:"
-        cat ${wait_fir_log}
+        cat ${wait_for_log}
         rm ${wait_for_log}
     fi
 
@@ -686,7 +686,7 @@ function evaluate_test_roadblock {
             sample_data_attempt_fail[${iter_array_idx}]=1;
 
             (( sample_data_failures[${iter_array_idx}]++ ))
-            printf "sample failures is now: %d\n", ${sample_data_failures[${iter_array_idx}]}
+            printf "sample failures is now: %d\n" ${sample_data_failures[${iter_array_idx}]}
 
             if [ ${sample_data_failures[${iter_array_idx}]} -ge ${max_sample_failures} ]; then
                 sample_data_complete[${iter_array_idx}]=1
@@ -1225,8 +1225,8 @@ function call_endpoint_specific_function() {
 }
 
 get_benchmark_from_id() {
-    local this_id = $1; shift
-    echo ${ids_to_bench[$this_id]}
+    local this_id=$1; shift
+    echo ${id_to_bench[$this_id]}
 }
 
 function make_osruntime_boostrap_script() {

--- a/endpoints/endpoints.py
+++ b/endpoints/endpoints.py
@@ -323,6 +323,21 @@ def validate_error(msg):
     """
     return print("ERROR: " + msg)
 
+def validate_warning(msg):
+    """
+    Log a validation warning message
+
+    Args:
+        msg (str): The message to log
+
+    Globals:
+        None
+
+    Returns:
+        None
+    """
+    return print("# WARNING: " + msg)
+
 def validate_debug(msg):
     """
     Log a vlidation debug message

--- a/endpoints/endpoints.py
+++ b/endpoints/endpoints.py
@@ -156,7 +156,7 @@ def run_remote(connection, command, validate = False, debug = False, stdin = Non
 
         msg = "Modified command: %s" % (command)
         if validate:
-            valiate_debug(msg)
+            validate_debug(msg)
         else:
             logger.debug(msg)
 
@@ -571,7 +571,7 @@ def get_controller_ip(host):
                     remote_ip = split_line[1]
                     break
         if remote_ip is None or not is_ip(remote_ip):
-            raise ValueError("Failed to determine remote IP address (got '%s')" % (endpoint_ip))
+            raise ValueError("Failed to determine remote IP address (got '%s')" % (remote_ip))
 
     # now that we have the remote's ip address, figure out what
     # controller ip this remote will need to use to contact the
@@ -646,9 +646,9 @@ def do_roadblock(roadblock_id = None, label = None, timeout = None, messages = N
         logger.info("[%s] No roadblock wait-for" % (label))
     else:
         wait_for_log = tempfile.mkstemp(suffix = "log")
-        wait_for_log[0].close()
+        os.close(wait_for_log[0])
         wait_for_log = wait_for_log[1]
-        logger.info("[%s] Going to run this wait-for command: %s" % (label, wait_For))
+        logger.info("[%s] Going to run this wait-for command: %s" % (label, wait_for))
         logger.info("[%s] Going to log wait-for to this file: %s" % (label, wait_for_log))
 
     if not abort is None and not abort is False:
@@ -663,7 +663,7 @@ def do_roadblock(roadblock_id = None, label = None, timeout = None, messages = N
     result = run_local("ping -w 10 -c 4 " + redis_server)
     ping_log_msg = "[%s] Pinged redis server '%s' with return code %d:\nstdout:\n%sstderr:\n%s" % (label, redis_server, result.exited, result.stdout, result.stderr)
     if result.exited != 0:
-        logger.error(ping_log_mesg)
+        logger.error(ping_log_msg)
     else:
         logger.info(ping_log_msg)
 

--- a/endpoints/kube/kube.py
+++ b/endpoints/kube/kube.py
@@ -2089,7 +2089,7 @@ def create_tools_pods(abort_event):
             endpoints.log_result(result)
             if result.exited != 0:
                 logger.error("Did not create CRD for pod '%s'" % (pod_name))
-                failed_crds.append(engine_name)
+                failed_crds.append(pod_name)
             else:
                 logger.info("Created CRD for pod '%s'" % (pod_name))
                 created_crds.append(pod_name)
@@ -2824,9 +2824,9 @@ def test_start(msgs_dir, test_id, tx_msgs_dir):
                                         logger.info("Building ingress-lb using MetalLB pool '%s'" % (endpoint["metallb-pool"]))
 
                                         crd = build_network_crd_obj("ingress-lb",
-                                                                    build_metallb_crd(obj["server-engine"]),
+                                                                    build_metallb_crd(obj["server-engine"],
                                                                                       obj["ports"],
-                                                                                      endpoint["metallb-pool"])
+                                                                                      endpoint["metallb-pool"]))
 
                                         logger.info("Created ingress-lb CRD:\n%s" % (endpoints.dump_json(crd)))
                                         obj["crds"].append(crd)

--- a/engine/partition-cpus.py
+++ b/engine/partition-cpus.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import argparse
+import copy
 import logging
 from pathlib import Path
 

--- a/schema/rickshaw-settings.json
+++ b/schema/rickshaw-settings.json
@@ -14,11 +14,11 @@
                         "user": {
                             "description": "This parameter controls the default username that is used to connect to an endpoint",
                             "type": "string",
-                            "minLemgth": 1,
+                            "minLength": 1,
                             "default": "root"
                         }
                     },
-                    "additionalProperies": false,
+                    "additionalProperties": false,
                     "required": [
                         "user"
                     ]
@@ -105,11 +105,11 @@
             "type": "object",
             "properties": {
                 "default": {
-                    "decsription": "This object contains the default userenv definition for different engine types",
+                    "description": "This object contains the default userenv definition for different engine types",
                     "type": "object",
                     "properties": {
                         "benchmarks": {
-                            "descrition": "This parameter defines the default userenv for the client/server engines",
+                            "description": "This parameter defines the default userenv for the client/server engines",
                             "type": "string",
                             "minLength": 1
                         },

--- a/schema/sample-persistent-ids.json
+++ b/schema/sample-persistent-ids.json
@@ -73,12 +73,12 @@
         "additionalProperties": false
       },
       "additionalItems": false
-    },
-    "required": [
-      "sample-persistent-ids",
-      "samples",
-      "periods"
-    ],
-    "additionalProperties": false
-  }
+    }
+  },
+  "required": [
+    "sample-persistent-ids",
+    "samples",
+    "periods"
+  ],
+  "additionalProperties": false
 }

--- a/util/blockbreaker.py
+++ b/util/blockbreaker.py
@@ -103,13 +103,13 @@ def load_json_file(json_file):
     except FileNotFoundError as err:
          err_msg = f"Could not find JSON file { json_file }:{ err }"
     except IOError as err:
-         err_msg = "Could not open/read JSON file { json_file }:{ err }"
-    except Exception as err:
-         err_msg = f"Unexpected error opening JSON file { json_file }:{ err }"
+         err_msg = f"Could not open/read JSON file { json_file }:{ err }"
     except JSONDecodeError as err:
-         err_msg = f"Decoding JSON file %s has failed: { json_file }:{ err }"
+         err_msg = f"Decoding JSON file has failed: { json_file }:{ err }"
     except TypeError as err:
          err_msg = f"JSON object type error: { err }"
+    except Exception as err:
+         err_msg = f"Unexpected error opening JSON file { json_file }:{ err }"
     if err_msg is not None:
          print(err_msg, file=sys.stderr)
     return None   

--- a/util/ci-run-file-creator.py
+++ b/util/ci-run-file-creator.py
@@ -169,7 +169,7 @@ def update_endpoint_sub_type():
             if args.endpoint_sub_type == "NONE":
                 msg = "%s endpoint expected sub-type of either 'GENERIC', 'MICROK8S', or 'OCP' (not 'NONE')"
                 log.error(msg)
-                raise VelueError(msg)
+                raise ValueError(msg)
 
     return
 

--- a/util/generate-ci-jobs.py
+++ b/util/generate-ci-jobs.py
@@ -485,7 +485,7 @@ def get_userenvs(logger):
         logger.info("Creating final userenvs through rickshaw userenv PR process")
 
         for userenv in userenvs:
-            logger.info("Adding '%s' userenv")
+            logger.info("Adding '%s' userenv", userenv)
             final_userenvs.append(userenv)
 
         logger.info("Total userenvs added: %d" % (len(final_userenvs)))

--- a/util/validate_run_file.py
+++ b/util/validate_run_file.py
@@ -4,6 +4,7 @@
 
 from blockbreaker import load_json_file,validate_schema
 import argparse
+import sys
 
 def process_options():
     """Handle the CLI argument parsing options"""
@@ -26,6 +27,8 @@ def validate(filename):
     if input_json is None:
         err_msg=f"Failed to load run-file JSON { filename }"
         rc=1
+        print(f"ERROR: { err_msg }", file=sys.stderr)
+        return rc
 
     if not validate_schema(input_json):
         err_msg=f"Failed to validate run-file JSON { filename } against schema."


### PR DESCRIPTION
## Summary

Fixes 5 critical bugs identified by the PERFNFV-334 codebase audit, each in a separate commit:

- **endpoints.py** (PERFNFV-341): 5 NameError/AttributeError bugs in error/debug paths — typos in function/variable names, incorrect fd close method
- **kube.py** (PERFNFV-342): misplaced closing paren gives `build_metallb_crd` 1 arg instead of 3, undefined `engine_name` in error path, missing `validate_warning()` function added to endpoints.py
- **engine/util scripts** (PERFNFV-344): missing `import copy`/`import sys`, `VelueError` typo, missing early return after JSON load failure, exception handler ordering (generic `except Exception` before specific handlers), missing f-string prefix, missing logger format argument
- **JSON schemas** (PERFNFV-345): 4 misspelled keywords in rickshaw-settings.json (`minLemgth`, `additionalProperies`, `decsription`, `descrition`), and `required`/`additionalProperties` placed inside `properties` block in sample-persistent-ids.json
- **endpoints/base** (PERFNFV-346): `get_benchmark_from_id()` completely broken (spaces in local assignment + array name mismatch), missing `$` in conditional, comma instead of space in printf, variable name typo

## Jira

- [PERFNFV-341](https://redhat.atlassian.net/browse/PERFNFV-341)
- [PERFNFV-342](https://redhat.atlassian.net/browse/PERFNFV-342)
- [PERFNFV-344](https://redhat.atlassian.net/browse/PERFNFV-344)
- [PERFNFV-345](https://redhat.atlassian.net/browse/PERFNFV-345)
- [PERFNFV-346](https://redhat.atlassian.net/browse/PERFNFV-346)

## Test plan

- [x] `python3 -m py_compile` passes on all modified Python files
- [x] `bash -n endpoints/base` passes
- [x] `jq .` validates modified JSON schemas
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)