### PR TITLE
fix: find engine-env.txt when metric files are in postprocess/ subdirectory

### DIFF
--- a/rickshaw-gen-docs.py
+++ b/rickshaw-gen-docs.py
@@ -192,6 +192,13 @@ def generate_metrics(cdm, result, metr_dir, metr_file, cstype, csid, base_doc,
     eng_env_file = os.path.join(metr_dir, "engine-env.txt")
     if not os.path.exists(eng_env_file):
         eng_env_file += ".xz"
+    if not os.path.exists(eng_env_file):
+        # When metric files are in a postprocess/ subdirectory,
+        # engine-env.txt is in the parent directory
+        parent_dir = os.path.dirname(metr_dir)
+        eng_env_file = os.path.join(parent_dir, "engine-env.txt")
+        if not os.path.exists(eng_env_file):
+            eng_env_file += ".xz"
     if os.path.exists(eng_env_file):
         varnames = ["HOSTNAME", "tool_name", "engine_type", "engine_role",
                      "benchmark_group", "benchmark_role", "hosted_by",


### PR DESCRIPTION
## Summary

- The `postprocess/` subdirectory feature (f98e1c6) moves metric files into a `postprocess/` subdirectory but `engine-env.txt` remains in the parent tool directory
- `generate_metrics()` only looked for `engine-env.txt` in `metr_dir`, so when `metr_dir` pointed to `postprocess/` the file was not found and all engine environment breakouts (`hostname`, `endpoint-label`, `hosted-by`, `osruntime`, `userenv`, `hypervisor-host`) were silently dropped from indexed metric descriptors
- Adds a parent-directory fallback so `engine-env.txt` is found regardless of whether metric files live in the tool directory or its `postprocess/` subdirectory

Closes #849
PERFNFV-394

## Test plan

- [x] Re-indexed an affected run and confirmed all engine-env breakouts are restored
- [x] Verified `crucible get metric --source=mpstat --type=Busy-CPU` now shows `hostname` and other engine-env breakouts in the available breakouts list

🤖 Generated with [Claude Code](https://claude.com/claude-code)