### PR TITLE
fix: remotehosts log formatting, undefined vars, and rickshaw-run RS_TAGS/schema_fixup bugs

### DIFF
--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -661,7 +661,8 @@ def create_thread_pool(description, acronym, work, worker_threads_count, worker_
 
     rc = 0
     for thread_rc in worker_threads_rcs:
-        rc += thread_rc
+        if thread_rc is not None:
+            rc += thread_rc
     thread_logger("Aggregate return code for %s: %d" % (acronym, rc))
 
     return rc

--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -390,7 +390,7 @@ def build_unique_remote_configs():
 
         start_tools,err = load_json_file(settings["dirs"]["local"]["tool-cmds"] + "/profiler/start.json.xz", uselzma = True)
         if start_tools is None:
-            logger.error("Failed to load the start tools command file from %s" % (tool_cmd_dir))
+            logger.error("Failed to load the start tools command file from %s" % (settings["dirs"]["local"]["tool-cmds"]))
             return 1
 
         profiler_count += 1

--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -535,7 +535,7 @@ def image_pull_worker_thread(thread_id, work_queue, threads_rcs):
                 loglevel = "info"
                 if result.exited != 0:
                     loglevel = "error"
-                thread_logger("Attempted to pull %s with return code %d:\nstdout:\n%sstderr:\n%s" % (image_info["image"], result.exited, result.stdout, result.stderr), log_level = loglevel, remote_name = remote)
+                thread_logger("Attempted to pull %s with return code %d:\nstdout:\n%s\nstderr:\n%s" % (image_info["image"], result.exited, result.stdout, result.stderr), log_level = loglevel, remote_name = remote)
                 rc += result.exited
 
                 if "auth-file" in image_info:
@@ -543,13 +543,13 @@ def image_pull_worker_thread(thread_id, work_queue, threads_rcs):
                     log_level = "info"
                     if result.exited != 0:
                         loglevel = "error"
-                    thread_logger("Attempted to remove %s with return code %d:\nstdout:\n%sstderr:\n%s" % (remote_auth_file, result.exited, result.stdout, result.stderr), log_level = loglevel, remote_name = remote)
+                    thread_logger("Attempted to remove %s with return code %d:\nstdout:\n%s\nstderr:\n%s" % (remote_auth_file, result.exited, result.stdout, result.stderr), log_level = loglevel, remote_name = remote)
 
                 result = endpoints.run_remote(c, "echo '" + image_info["image"] + " " + str(int(time.time())) + " " + settings["misc"]["run-id"] + "' >> " + settings["dirs"]["remote"]["base"] + "/remotehosts-container-image-census")
                 loglevel = "info"
                 if result.exited != 0:
                     loglevel = "error"
-                thread_logger("Recorded usage for %s in the census with return code %d:\nstdout:\n%sstderr:\n%s" % (image_info["image"], result.exited, result.stdout, result.stderr), log_level = loglevel, remote_name = remote)
+                thread_logger("Recorded usage for %s in the census with return code %d:\nstdout:\n%s\nstderr:\n%s" % (image_info["image"], result.exited, result.stdout, result.stderr), log_level = loglevel, remote_name = remote)
                 rc += result.exited
 
         thread_logger("Notifying work queue that job processing is complete", remote_name = remote)
@@ -769,7 +769,7 @@ def remote_mkdirs_worker_thread(thread_id, work_queue, threads_rcs):
         with endpoints.remote_connection(remote, my_run_file_remote["config"]["settings"]["remote-user"]) as con:
             for remote_dir in settings["dirs"]["remote"].keys():
                 result = endpoints.run_remote(con, "mkdir --parents --verbose " + settings["dirs"]["remote"][remote_dir])
-                thread_logger("Remote attempted to mkdir %s with return code %d:\nstdout:\n%sstderr:\n%s" % (settings["dirs"]["remote"][remote_dir], result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote)
+                thread_logger("Remote attempted to mkdir %s with return code %d:\nstdout:\n%s\nstderr:\n%s" % (settings["dirs"]["remote"][remote_dir], result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote)
                 rc += result.exited
 
         thread_logger("Notifying work queue that job processing is complete", remote_name = remote)
@@ -946,7 +946,7 @@ def create_podman(thread_name, remote_name, engine_name, container_name, connect
     thread_logger("Podman create command is:\n%s" % (endpoints.dump_json(create_cmd)), remote_name = remote_name, engine_name = engine_name)
 
     result = endpoints.run_remote(connection, " ".join(create_cmd))
-    thread_logger("Creating container with name '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+    thread_logger("Creating container with name '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
     return
 
@@ -989,7 +989,7 @@ def create_chroot(thread_name, remote_name, engine_name, container_name, connect
     thread_logger("Podman create command is:\n%s" % (endpoints.dump_json(create_cmd)), remote_name = remote_name, engine_name = engine_name)
 
     result = endpoints.run_remote(connection, " ".join(create_cmd))
-    thread_logger("Creating container with name '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+    thread_logger("Creating container with name '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
     if result.exited == 0:
         create_info["id"] = result.stdout.rstrip('\n')
     else:
@@ -1000,7 +1000,7 @@ def create_chroot(thread_name, remote_name, engine_name, container_name, connect
                   container_name ]
 
     result = endpoints.run_remote(connection, " ".join(mount_cmd))
-    thread_logger("Mounting container with name '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+    thread_logger("Mounting container with name '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
     if result.exited == 0:
         create_info["mount"] = result.stdout.rstrip('\n')
     else:
@@ -1060,19 +1060,19 @@ def create_chroot(thread_name, remote_name, engine_name, container_name, connect
         thread_logger("Procesing mount:\n%s" % (endpoints.dump_json(mount)), remote_name = remote_name, engine_name = engine_name)
 
         result = endpoints.run_remote(connection, "mkdir --parents --verbose " + mount["dest"])
-        thread_logger("Creating '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (mount["dest"], result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+        thread_logger("Creating '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (mount["dest"], result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
         if mount["rbind"]:
             result = endpoints.run_remote(connection, "mount --verbose --options rbind " + mount["src"] + " " + mount["dest"])
-            thread_logger("rbind mounting '%s' to '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (mount["src"], mount["dest"], result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+            thread_logger("rbind mounting '%s' to '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (mount["src"], mount["dest"], result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
             result = endpoints.run_remote(connection, "mount --verbose --make-rslave " + mount["dest"])
-            thread_logger("making rslave '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (mount["dest"], result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+            thread_logger("making rslave '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (mount["dest"], result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
             create_info["mounts"]["rbind"].append(mount["dest"])
         else:
             result = endpoints.run_remote(connection, "mount --verbose --options bind " + mount["src"] + " " + mount["dest"])
-            thread_logger("bind mounting '%s' to '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (mount["src"], mount["dest"], result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+            thread_logger("bind mounting '%s' to '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (mount["src"], mount["dest"], result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
             create_info["mounts"]["regular"].append(mount["dest"])
 
@@ -1117,7 +1117,7 @@ def start_podman(thread_name, remote_name, engine_name, container_name, connecti
     ]
 
     result = endpoints.run_remote(connection, " ".join(start_cmd))
-    thread_logger("Starting container with name '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+    thread_logger("Starting container with name '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
     return
 
@@ -1194,7 +1194,7 @@ def start_chroot(thread_name, remote_name, engine_name, container_name, connecti
     thread_logger("chroot start command is:\n%s" % (endpoints.dump_json(start_cmd)), remote_name = remote_name, engine_name = engine_name)
 
     result = endpoints.run_remote(connection, " ".join(start_cmd))
-    thread_logger("Starting chroot with name '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+    thread_logger("Starting chroot with name '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
     return
 
@@ -1272,14 +1272,14 @@ def launch_engines_worker_thread(thread_id, work_queue, threads_rcs):
                     thread_logger("host-mounts is %s" % (remote["config"]["settings"]["host-mounts"]), remote_name = remote_name, engine_name = engine_name)
 
                     result = endpoints.run_remote(con, "podman ps --all --filter 'name=" + container_name + "' --format '{{.Names}}'")
-                    thread_logger("Check for existing container with name '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), remote_name = remote_name, engine_name = engine_name)
+                    thread_logger("Check for existing container with name '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), remote_name = remote_name, engine_name = engine_name)
                     if result.exited != 0:
                         thread_logger("Check for existing container exited with non-zero return code %d" % (result.exited), log_level = "error", remote_name = remote_name, engine_name = engine_name)
                     if result.stdout.rstrip('\n') == container_name:
                         thread_logger("Found existing container '%s'" % (container_name), log_level = "warning", remote_name = remote_name, engine_name = engine_name)
 
                         result = endpoints.run_remote(con, "podman rm --force " + container_name)
-                        thread_logger("Forced removal of existing container with name '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), remote_name = remote_name, engine_name = engine_name)
+                        thread_logger("Forced removal of existing container with name '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (container_name, result.exited, result.stdout, result.stderr), remote_name = remote_name, engine_name = engine_name)
                         if result.exited != 0:
                             thread_logger("Forced removal of existing container exited with non-zero return code %d" % (result.exited), log_level = 'error', remote_name = remote_name, engine_name = engine_name)
 
@@ -1552,7 +1552,7 @@ def collect_podman_log(thread_name, remote_name, engine_name, container_name, co
     while cmd_rc != 0 and cmd_attempt <= cmd_retries:
         result = endpoints.run_remote(connection, "podman logs --timestamps " + container_name + " | xz -c | base64")
         if result.exited != 0:
-            thread_logger("Collecting podman log for %s failed with return code %d on attempt %d of %d:\nstdout:\n%sstderr:\n%s" %
+            thread_logger("Collecting podman log for %s failed with return code %d on attempt %d of %d:\nstdout:\n%s\nstderr:\n%s" %
                         (
                             engine_name,
                             result.exited,
@@ -1599,7 +1599,7 @@ def collect_chroot_log(thread_name, remote_name, engine_name, container_name, co
     remote_log_file = settings["dirs"]["remote"]["logs"] + "/" + engine_name + ".txt"
     result = endpoints.run_remote(connection, "cat " + remote_log_file + " | xz -c | base64")
     if result.exited != 0:
-        thread_logger("Collecting chroot log for %s failed with return code %d:\nstdout:\n%sstderr:\n%s" %
+        thread_logger("Collecting chroot log for %s failed with return code %d:\nstdout:\n%s\nstderr:\n%s" %
                       (
                           engine_name,
                           result.exited,
@@ -1641,7 +1641,7 @@ def remove_rickshaw_settings(connection, thread_name, remote_name, engine_name):
     """
     remote_rickshaw_settings = settings["dirs"]["remote"]["data"] + "/rickshaw-settings.json.xz"
     result = endpoints.run_remote(connection, "if [ -e \"" + remote_rickshaw_settings + "\" ]; then rm --verbose \"" + remote_rickshaw_settings + "\"; else echo \"rickshaw settings already removed\"; fi")
-    thread_logger("Removal of rickshaw settings '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (remote_rickshaw_settings, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+    thread_logger("Removal of rickshaw settings '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (remote_rickshaw_settings, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
     return
 
@@ -1663,7 +1663,7 @@ def remove_ssh_private_key(connection, thread_name, remote_name, engine_name):
     """
     remote_ssh_private_key = settings["dirs"]["remote"]["data"] + "/rickshaw_ssh_id"
     result = endpoints.run_remote(connection, "if [ -e \"" + remote_ssh_private_key + "\" ]; then rm --verbose \"" + remote_ssh_private_key + "\"; else echo \"ssh private key already removed\"; fi")
-    thread_logger("Removal of ssh private key '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (remote_ssh_private_key, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+    thread_logger("Removal of ssh private key '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (remote_ssh_private_key, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
     return
 
@@ -1687,11 +1687,11 @@ def destroy_podman(thread_name, remote_name, engine_name, container_name, connec
     thread_logger("Destroying podman", remote_name = remote_name, engine_name = engine_name)
 
     result = endpoints.run_remote(connection, "podman rm --force " + container_name)
-    thread_logger("Removal of pod '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (engine_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+    thread_logger("Removal of pod '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (engine_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
     remote_env_file = settings["dirs"]["remote"]["cfg"] + "/" + engine_name + "_env.txt"
     result = endpoints.run_remote(connection, "rm --verbose " + remote_env_file)
-    thread_logger("Removal of env file  '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (remote_env_file, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+    thread_logger("Removal of env file  '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (remote_env_file, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
     remove_ssh_private_key(connection, thread_name, remote_name, engine_name)
 
@@ -1721,14 +1721,14 @@ def destroy_chroot(thread_name, remote_name, engine_name, container_name, connec
 
     for mount in chroot_info["mounts"]["regular"]:
         result = endpoints.run_remote(connection, "umount --verbose " + mount)
-        thread_logger("regular unmounting of '%s' resulted in record code %d:\nstdout:\n%sstderr:\n%s" % (mount, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+        thread_logger("regular unmounting of '%s' resulted in record code %d:\nstdout:\n%s\nstderr:\n%s" % (mount, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
     for mount in chroot_info["mounts"]["rbind"]:
         result = endpoints.run_remote(connection, "umount --verbose --recursive " + mount)
-        thread_logger("recursive unmounting of '%s' resulted in record code %d:\nstdout:\n%sstderr:\n%s" % (mount, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+        thread_logger("recursive unmounting of '%s' resulted in record code %d:\nstdout:\n%s\nstderr:\n%s" % (mount, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
     result = endpoints.run_remote(connection, "podman rm --force " + container_name)
-    thread_logger("Removal of pod '%s' resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (engine_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+    thread_logger("Removal of pod '%s' resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (engine_name, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
 
     remove_ssh_private_key(connection, thread_name, remote_name, engine_name)
 
@@ -1755,7 +1755,7 @@ def remove_image(thread_name, remote_name, log_prefix, connection, image):
     thread_logger("Removing image '%s'" % (image), remote_name = remote_name, log_prefix = log_prefix)
 
     result = endpoints.run_remote(connection, "podman rmi " + image)
-    thread_logger("Removing podman image '%s' gave return code %d:\nstdout:\n%sstderr:\n%s" % (image, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, log_prefix = log_prefix)
+    thread_logger("Removing podman image '%s' gave return code %d:\nstdout:\n%s\nstderr:\n%s" % (image, result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, log_prefix = log_prefix)
 
     return
 
@@ -1781,7 +1781,7 @@ def remote_image_manager(thread_name, remote_name, connection, image_max_cache_s
     thread_logger("Performing container image management", remote_name = remote_name, log_prefix = log_prefix)
 
     result = endpoints.run_remote(connection, "podman images --all")
-    thread_logger("All podman images on this remote host before running image manager:\nstdout:\n%sstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+    thread_logger("All podman images on this remote host before running image manager:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
     images = dict()
     images["rickshaw"] = dict()
@@ -1790,7 +1790,7 @@ def remote_image_manager(thread_name, remote_name, connection, image_max_cache_s
 
     result = endpoints.run_remote(connection, "cat /var/lib/crucible/remotehosts-container-image-census")
     if result.exited != 0:
-        thread_logger("Reading image census returned %d:\nstdout:\n%sstderr:\n%s" % (result.exited, result.stdout, result.stderr), log_level = "error", remote_name = remote_name, log_prefix = log_prefix)
+        thread_logger("Reading image census returned %d:\nstdout:\n%s\nstderr:\n%s" % (result.exited, result.stdout, result.stderr), log_level = "error", remote_name = remote_name, log_prefix = log_prefix)
         return
     for line in result.stdout.splitlines():
         fields = line.split(" ")
@@ -1813,7 +1813,7 @@ def remote_image_manager(thread_name, remote_name, connection, image_max_cache_s
 
     result = endpoints.run_remote(connection, "podman images --format='{{.Repository}}:{{.Tag}}|{{.CreatedAt}}'")
     if result.exited != 0:
-        thread_logger("Getting podman images returned %d:\nstdout:\n%sstderr:\n%s" % (result.exited, result.stdout, result.stderr), log_level = "error", remote_name = remote_name, log_prefix = log_prefix)
+        thread_logger("Getting podman images returned %d:\nstdout:\n%s\nstderr:\n%s" % (result.exited, result.stdout, result.stderr), log_level = "error", remote_name = remote_name, log_prefix = log_prefix)
         return
     for line in result.stdout.splitlines():
         fields = line.split("|")
@@ -2066,10 +2066,10 @@ def remote_image_manager(thread_name, remote_name, connection, image_max_cache_s
         thread_logger("All rickshaw images are cached", remote_name = remote_name, log_prefix = log_prefix)
 
     result = endpoints.run_remote(connection, "podman image prune -f")
-    thread_logger("Pruning dangling images resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, log_prefix = log_prefix)
+    thread_logger("Pruning dangling images resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote_name, log_prefix = log_prefix)
 
     result = endpoints.run_remote(connection, "podman images --all")
-    thread_logger("All podman images on this remote host after running image manager:\nstdout:\n%sstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+    thread_logger("All podman images on this remote host after running image manager:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
     return
 
@@ -2117,13 +2117,13 @@ def shutdown_engines_worker_thread(thread_id, work_queue, threads_rcs):
 
         with endpoints.remote_connection(remote["config"]["host"], remote["config"]["settings"]["remote-user"]) as con:
             result = endpoints.run_remote(con, "mount")
-            thread_logger("All mounts on this remote host:\nstdout:\n%sstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+            thread_logger("All mounts on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
             result = endpoints.run_remote(con, "podman ps --all")
-            thread_logger("All podman pods on this remote host:\nstdout:\n%sstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+            thread_logger("All podman pods on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
             result = endpoints.run_remote(con, "podman mount")
-            thread_logger("All podman container mounts on this remote host:\nstdout:\n%sstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+            thread_logger("All podman container mounts on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
             for engine in remote["engines"]:
                 for engine_id in engine["ids"]:
@@ -2150,13 +2150,13 @@ def shutdown_engines_worker_thread(thread_id, work_queue, threads_rcs):
                                 destroy_chroot(thread_name, remote_name, engine_name, container_name, con, remote["chroots"][engine_name])
 
             result = endpoints.run_remote(con, "mount")
-            thread_logger("All mounts on this remote host:\nstdout:\n%sstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+            thread_logger("All mounts on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
             result = endpoints.run_remote(con, "podman ps --all")
-            thread_logger("All podman pods on this remote host:\nstdout:\n%sstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+            thread_logger("All podman pods on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
             result = endpoints.run_remote(con, "podman mount")
-            thread_logger("All podman container mounts on this remote host:\nstdout:\n%sstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+            thread_logger("All podman container mounts on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
         thread_logger("Notifying work queue that job processing is complete", remote_name = remote_name)
         work_queue.task_done()
@@ -2336,7 +2336,7 @@ def collect_sysinfo_worker_thread(thread_id, work_queue, threads_rcs):
             thread_logger("Copied %s to %s:%s" % (local_packrat_file, remote, remote_packrat_file), remote_name = remote)
 
             result = endpoints.run_remote(con, remote_packrat_file + " " + settings["dirs"]["remote"]["sysinfo"])
-            thread_logger("Running packrat resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote)
+            thread_logger("Running packrat resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote)
 
             result = endpoints.run_remote(con, "tar --create --directory " + settings["dirs"]["remote"]["sysinfo"]  + " packrat-archive | xz --stdout | base64")
             thread_logger("Transferring packrat files resulted in return code %d:\nstderr:\n%s" % (result.exited, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote)
@@ -2347,14 +2347,14 @@ def collect_sysinfo_worker_thread(thread_id, work_queue, threads_rcs):
             thread_logger("Wrote packrat archive to '%s'" % (archive_file), remote_name = remote)
 
             result = endpoints.run_local("xz --decompress --stdout " + archive_file + " | tar --extract --verbose --directory " + local_dir)
-            thread_logger("Unpacking packrat archive resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote)
+            thread_logger("Unpacking packrat archive resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote)
 
             path = Path(archive_file)
             path.unlink()
             thread_logger("Removed packrat archive '%s'" % (archive_file), remote_name = remote)
 
             result = endpoints.run_remote(con, "rm --recursive --force " + remote_packrat_file + " " + settings["dirs"]["remote"]["sysinfo"] + "/packrat-archive")
-            thread_logger("Removing remote packrat files resulted in return code %d:\nstdout:\n%sstderr:\n%s" % (result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote)
+            thread_logger("Removing remote packrat files resulted in return code %d:\nstdout:\n%s\nstderr:\n%s" % (result.exited, result.stdout, result.stderr), log_level = endpoints.get_result_log_level(result), remote_name = remote)
 
         thread_logger("Notifying work queue that job processing is complete", remote_name = remote)
         work_queue.task_done()

--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -702,7 +702,7 @@ def remotes_pull_images():
 
                 if userenv is None:
                     logger.error("Cound not find userenv for remote %s with role %s and id %s" % (remote, role, str(id)))
-                    print("could not find userenv for " + endpoint)
+                    print("could not find userenv for " + remote)
                 else:
                     remote_arch = settings["engines"]["remotes"][remote].get("arch")
                     image_info = endpoints.get_engine_id_image(settings, role, id, userenv, arch=remote_arch)

--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -229,7 +229,6 @@ class RunState:
 
         self.messages_ref = None
         self.abort_via_roadblock = False
-        self.abort_test_id = None
         self.endpoint_processes = []
 
         self.arch = platform.machine()
@@ -2422,14 +2421,6 @@ def main():
     state.run["max-sample-failures"] = int(state.run.get("max-sample-failures", 1))
     state.run["num-samples"] = int(state.run.get("num-samples", 1))
     save_json_file(run_file, state.run)
-
-    if state.abort_test_id is not None:
-        logger.warning(
-            "WARNING: test %s was aborted. and all subsequent tests were not attempted. Run is incomplete",
-            state.abort_test_id
-        )
-        sys.exit(1)
-
 
 if __name__ == "__main__":
     main()

--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -2372,7 +2372,18 @@ def main():
         if e in os.environ:
             var = e.replace("RS_", "").lower().replace("_", "-")
             logger.debug("Found environment variable: %s, assigning '%s' to %s", e, os.environ[e], var)
-            state.run[var] = os.environ[e]
+            if var == "tags":
+                if "tags" not in state.run:
+                    state.run["tags"] = []
+                for this_tag in os.environ[e].split(","):
+                    m = re.match(r'(\S+):(\S+)', this_tag)
+                    if m:
+                        state.run["tags"].append({"name": m.group(1), "val": m.group(2)})
+                    else:
+                        logger.error("ERROR: format for RS_TAGS value is not valid: %s", this_tag)
+                        sys.exit(1)
+            else:
+                state.run[var] = os.environ[e]
 
     state.process_cmdline()
     state.load_settings_info()

--- a/rickshaw_lib/schema_fixup.py
+++ b/rickshaw_lib/schema_fixup.py
@@ -68,6 +68,10 @@ def rickshaw_run_schema_fixup(result_file, result_schema_file):
                 if isinstance(tv, str):
                     result_data["registries"][reg_type]["tls-verify"] = tv.lower() == "true"
 
+                qr = result_data["registries"][reg_type].get("quay-refresh-expiration-require-success")
+                if isinstance(qr, str):
+                    result_data["registries"][reg_type]["quay-refresh-expiration-require-success"] = qr.lower() == "true"
+
     valid, err = validate_schema(result_data, result_schema_file)
     if not valid:
         logger.error(

--- a/rickshaw_lib/schema_fixup.py
+++ b/rickshaw_lib/schema_fixup.py
@@ -43,16 +43,9 @@ def rickshaw_run_schema_fixup(result_file, result_schema_file):
 
     logger.info("Checking if the rickshaw-run data matches the current JSON schema")
 
-    schema_data, schema_err = load_json_file(result_schema_file)
-    if schema_data is None:
-        logger.error("Could not load schema: %s", schema_err)
-        return 1
-
-    try:
-        validate_schema(schema_data, result_data)
+    valid, err = validate_schema(result_data, result_schema_file)
+    if valid:
         return 0
-    except Exception:
-        pass
 
     logger.info("Attempting to update the rickshaw-run data to match the current JSON schema")
 
@@ -64,11 +57,10 @@ def rickshaw_run_schema_fixup(result_file, result_schema_file):
             except (ValueError, TypeError):
                 pass
 
-    try:
-        validate_schema(schema_data, result_data)
-    except Exception as e:
+    valid, err = validate_schema(result_data, result_schema_file)
+    if not valid:
         logger.error(
-            "Unable to validate rickshaw-run data after schema fixup: %s", e
+            "Unable to validate rickshaw-run data after schema fixup: %s", err
         )
         return 1
 

--- a/rickshaw_lib/schema_fixup.py
+++ b/rickshaw_lib/schema_fixup.py
@@ -57,6 +57,17 @@ def rickshaw_run_schema_fixup(result_file, result_schema_file):
             except (ValueError, TypeError):
                 pass
 
+    # Convert tls-verify fields from string to boolean
+    if "reg-tls-verify" in result_data and isinstance(result_data["reg-tls-verify"], str):
+        result_data["reg-tls-verify"] = result_data["reg-tls-verify"].lower() == "true"
+
+    if "registries" in result_data:
+        for reg_type in ("public", "private"):
+            if reg_type in result_data["registries"]:
+                tv = result_data["registries"][reg_type].get("tls-verify")
+                if isinstance(tv, str):
+                    result_data["registries"][reg_type]["tls-verify"] = tv.lower() == "true"
+
     valid, err = validate_schema(result_data, result_schema_file)
     if not valid:
         logger.error(

--- a/schema/rickshaw-run.json
+++ b/schema/rickshaw-run.json
@@ -122,7 +122,7 @@
     },
     "reg-tls-verify": {
       "description": "Legacy field: registry TLS verification setting.",
-      "type": "string"
+      "type": "boolean"
     },
     "registries": {
       "description": "Container registry configuration for private and public registries used for engine image storage.",
@@ -398,11 +398,7 @@
         },
         "tls-verify": {
           "description": "Whether TLS certificate verification is enabled for this registry.",
-          "type": "string",
-          "enum": [
-            "false",
-            "true"
-          ]
+          "type": "boolean"
         },
         "url-details": {
           "description": "Decoded components of the repository URL, populated by rickshaw-run after parsing the repo URL.",

--- a/schema/rickshaw-run.json
+++ b/schema/rickshaw-run.json
@@ -378,11 +378,7 @@
         },
         "quay-refresh-expiration-require-success": {
           "description": "Whether a successful image push is required before refreshing the expiration timer.",
-          "type": "string",
-          "enum": [
-            "false",
-            "true"
-          ]
+          "type": "boolean"
         },
         "quay-refresh-expiration-api-url": {
           "description": "The Quay API URL used for refreshing image tag expirations.",


### PR DESCRIPTION
## Summary

### PERFNFV-343: remotehosts.py fixes
- Add missing `\n` before `stderr:` label in 39 log format strings — stdout was running directly into the label
- Fix undefined `endpoint` variable in userenv error message — should be `remote` (NameError)
- Fix undefined `tool_cmd_dir` in error message — should be `settings["dirs"]["local"]["tool-cmds"]` (NameError)
- Skip `None` entries when aggregating worker thread return codes — unstarted thread slots caused TypeError

### PERFNFV-347: rickshaw-run.py and schema_fixup.py fixes
- Parse `RS_TAGS` env var into tag list-of-dicts format instead of assigning raw string — `.append()` on a string raised AttributeError
- Remove dead `abort_test_id` code — initialized to None, never assigned, warning block unreachable
- Fix swapped `validate_schema()` arguments in schema_fixup.py — was passing `(schema_data, result_data)` where `(result_data, schema_file_path)` was expected. Also fix calling convention: `validate_schema` returns `(bool, err)`, not exceptions

Closes #839
Closes #843

## Test plan
- [ ] CI passes
- [ ] `python3 -c "import py_compile; py_compile.compile('...', doraise=True)"` for all modified files
- [ ] Verify schema_fixup handles both valid and fixable rickshaw-run.json files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)