### PR TITLE
fix: use attempt-fail instead of self.abort for failure counting guard

### DIFF
--- a/engine/engine_lib.py
+++ b/engine/engine_lib.py
@@ -704,7 +704,7 @@ class Engine:
 
         if result["is_timeout"]:
             self.quit = True
-        if result["is_abort"] and not self.abort:
+        if result["is_abort"] and not sample_data[iter_idx]["attempt-fail"]:
             sample_data[iter_idx]["attempt-fail"] = True
             sample_data[iter_idx]["failures"] += 1
             logger.info(


### PR DESCRIPTION
## Summary

- Fix engine abort failure counting bug that causes catastrophic roadblock cascade on benchmark failure

## Root cause

When `run_bench_cmd()` detects a non-zero return code, it sets `self.abort = True` **before** `_roadblock_and_evaluate()` runs. The evaluate function's guard `not self.abort` then prevents it from incrementing the failure counter or setting `sd["complete"]`. The engine starts a phantom second attempt that nobody else participates in, causing every remaining roadblock to timeout (4 min each) and `wait_for_endpoints()` to block indefinitely.

The controller and endpoint don't have this bug — they use local `abort` variables per attempt.

## Fix

Change the guard from `not self.abort` to `not sample_data[iter_idx]["attempt-fail"]`. Same double-counting prevention, no timing dependency.

## Verified results

| | Before | After |
|---|---|---|
| Post-bench roadblocks | 30+ min (cascading 4-min timeouts) | **16 seconds** |
| wait_for_endpoints | Infinite hang | Clean exit |
| Diagnostic files | Lost (chroot destroyed) | **Preserved** (send-data completes) |
| Total failure time | 30+ min + hang | **~3 minutes** |

## Test plan

- [x] Reproduced on trafficgen with CX-6 LX (TRex startup failure)
- [x] Verified engine correctly exits while loop after 1 failure
- [x] Verified all post-bench roadblocks complete without timeouts
- [x] Verified send-data phase completes and diagnostic files are archived
- [x] Verified `trafficgen-infra-stderrout.txt` and `trex-server-stderrout.txt` are available in run results

Resolves: https://github.com/perftool-incubator/rickshaw/issues/853

🤖 Generated with [Claude Code](https://claude.com/claude-code)