### PR TITLE
feat: rescue engine logs and harden cleanup on early roadblock failure

### DIFF
--- a/endpoints/endpoints.py
+++ b/endpoints/endpoints.py
@@ -1021,6 +1021,7 @@ def process_roadblocks(callbacks = None, roadblock_id = None, endpoint_label = N
     else:
         logger.info("No new followers to inform the roadblock leader about")
 
+    # Separate flag because finally also fires on uncaught exceptions, not just rc != 0 returns
     roadblocks_completed = False
 
     try:

--- a/endpoints/endpoints.py
+++ b/endpoints/endpoints.py
@@ -983,6 +983,7 @@ def process_roadblocks(callbacks = None, roadblock_id = None, endpoint_label = N
                           test-start
                           test-stop
                           remote-cleanup
+                          rescue-engine-logs
         roadblock_id (str): The base ID to use as part of a roadblock's name
         endpoint_label (str): The name of the calling endpoint
         endpoint_deploy_timeout (int): The computed timeout value for endpoint engine deployment
@@ -1020,130 +1021,144 @@ def process_roadblocks(callbacks = None, roadblock_id = None, endpoint_label = N
     else:
         logger.info("No new followers to inform the roadblock leader about")
 
-    rc = do_roadblock(roadblock_id = roadblock_id,
-                      follower_id = endpoint_label,
-                      label = "endpoint-deploy-begin",
-                      timeout = endpoint_deploy_timeout,
-                      messages = new_followers_msg_file,
-                      redis_password = roadblock_password,
-                      msgs_dir = roadblock_messages_dir,
-                      connection_watchdog = roadblock_connection_watchdog)
-    if rc != 0:
-        return rc
-    rc = do_roadblock(roadblock_id = roadblock_id,
-                      follower_id = endpoint_label,
-                      label = "endpoint-deploy-end",
-                      timeout = endpoint_deploy_timeout,
-                      redis_password = roadblock_password,
-                      msgs_dir = roadblock_messages_dir,
-                      abort = early_abort,
-                      connection_watchdog = roadblock_connection_watchdog)
-    if rc != 0:
-        return rc
+    roadblocks_completed = False
 
-    rc = do_roadblock(roadblock_id = roadblock_id,
-                      follower_id = endpoint_label,
-                      label = "engine-init-begin",
-                      timeout = roadblock_timeouts["engine-start"],
-                      redis_password = roadblock_password,
-                      msgs_dir = roadblock_messages_dir,
-                      connection_watchdog = roadblock_connection_watchdog)
-    if rc != 0:
-        return rc
-    callback = "engine-init"
-    engine_init_msgs = None
-    if callback in callbacks and callbacks[callback] is not None:
-        logger.info("Calling endpoint specified callback for '%s'" % (callback))
-        engine_init_msgs = callbacks[callback]()
-    else:
-        logger.info("Calling endpoint did not specify a callback for '%s'" % (callback))
-    rc = do_roadblock(roadblock_id = roadblock_id,
-                      follower_id = endpoint_label,
-                      label = "engine-init-end",
-                      timeout = roadblock_timeouts["engine-start"],
-                      messages = engine_init_msgs,
-                      redis_password = roadblock_password,
-                      msgs_dir = roadblock_messages_dir,
-                      connection_watchdog = roadblock_connection_watchdog)
-    if rc != 0:
-        return rc
+    try:
+        rc = do_roadblock(roadblock_id = roadblock_id,
+                          follower_id = endpoint_label,
+                          label = "endpoint-deploy-begin",
+                          timeout = endpoint_deploy_timeout,
+                          messages = new_followers_msg_file,
+                          redis_password = roadblock_password,
+                          msgs_dir = roadblock_messages_dir,
+                          connection_watchdog = roadblock_connection_watchdog)
+        if rc != 0:
+            return rc
+        rc = do_roadblock(roadblock_id = roadblock_id,
+                          follower_id = endpoint_label,
+                          label = "endpoint-deploy-end",
+                          timeout = endpoint_deploy_timeout,
+                          redis_password = roadblock_password,
+                          msgs_dir = roadblock_messages_dir,
+                          abort = early_abort,
+                          connection_watchdog = roadblock_connection_watchdog)
+        if rc != 0:
+            return rc
 
-    rc = do_roadblock(roadblock_id = roadblock_id,
-                      follower_id = endpoint_label,
-                      label = "get-data-begin",
-                      timeout = roadblock_timeouts["default"],
-                      redis_password = roadblock_password,
-                      msgs_dir = roadblock_messages_dir,
-                      connection_watchdog = roadblock_connection_watchdog)
-    if rc != 0:
-        return rc
-    rc = do_roadblock(roadblock_id = roadblock_id,
-                      follower_id = endpoint_label,
-                      label = "get-data-end",
-                      timeout = roadblock_timeouts["default"],
-                      redis_password = roadblock_password,
-                      msgs_dir = roadblock_messages_dir,
-                      connection_watchdog = roadblock_connection_watchdog)
-    if rc != 0:
-        return rc
+        rc = do_roadblock(roadblock_id = roadblock_id,
+                          follower_id = endpoint_label,
+                          label = "engine-init-begin",
+                          timeout = roadblock_timeouts["engine-start"],
+                          redis_password = roadblock_password,
+                          msgs_dir = roadblock_messages_dir,
+                          connection_watchdog = roadblock_connection_watchdog)
+        if rc != 0:
+            return rc
+        callback = "engine-init"
+        engine_init_msgs = None
+        if callback in callbacks and callbacks[callback] is not None:
+            logger.info("Calling endpoint specified callback for '%s'" % (callback))
+            engine_init_msgs = callbacks[callback]()
+        else:
+            logger.info("Calling endpoint did not specify a callback for '%s'" % (callback))
+        rc = do_roadblock(roadblock_id = roadblock_id,
+                          follower_id = endpoint_label,
+                          label = "engine-init-end",
+                          timeout = roadblock_timeouts["engine-start"],
+                          messages = engine_init_msgs,
+                          redis_password = roadblock_password,
+                          msgs_dir = roadblock_messages_dir,
+                          connection_watchdog = roadblock_connection_watchdog)
+        if rc != 0:
+            return rc
 
-    rc = do_roadblock(roadblock_id = roadblock_id,
-                      follower_id = endpoint_label,
-                      label = "collect-sysinfo-begin",
-                      timeout = roadblock_timeouts["collect-sysinfo"],
-                      redis_password = roadblock_password,
-                      msgs_dir = roadblock_messages_dir,
-                      connection_watchdog = roadblock_connection_watchdog)
-    if rc != 0:
-        return rc
-    callback = "collect-sysinfo"
-    engine_init_msgs = None
-    if callback in callbacks and callbacks[callback] is not None:
-        logger.info("Calling endpoint specified callback for '%s'" % (callback))
-        engine_init_msgs = callbacks[callback]()
-    else:
-        logger.info("Calling endpoint did not specify a callback for '%s'" % (callback))
-    rc = do_roadblock(roadblock_id = roadblock_id,
-                      follower_id = endpoint_label,
-                      label = "collect-sysinfo-end",
-                      timeout = roadblock_timeouts["collect-sysinfo"],
-                      redis_password = roadblock_password,
-                      msgs_dir = roadblock_messages_dir,
-                      connection_watchdog = roadblock_connection_watchdog)
-    if rc != 0:
-        return rc
+        rc = do_roadblock(roadblock_id = roadblock_id,
+                          follower_id = endpoint_label,
+                          label = "get-data-begin",
+                          timeout = roadblock_timeouts["default"],
+                          redis_password = roadblock_password,
+                          msgs_dir = roadblock_messages_dir,
+                          connection_watchdog = roadblock_connection_watchdog)
+        if rc != 0:
+            return rc
+        rc = do_roadblock(roadblock_id = roadblock_id,
+                          follower_id = endpoint_label,
+                          label = "get-data-end",
+                          timeout = roadblock_timeouts["default"],
+                          redis_password = roadblock_password,
+                          msgs_dir = roadblock_messages_dir,
+                          connection_watchdog = roadblock_connection_watchdog)
+        if rc != 0:
+            return rc
 
-    rc = do_roadblock(roadblock_id = roadblock_id,
-                      follower_id = endpoint_label,
-                      label = "start-tools-begin",
-                      timeout = roadblock_timeouts["default"],
-                      redis_password = roadblock_password,
-                      msgs_dir = roadblock_messages_dir,
-                      connection_watchdog = roadblock_connection_watchdog)
-    if rc != 0:
-        return rc
-    rc = do_roadblock(roadblock_id = roadblock_id,
-                      follower_id = endpoint_label,
-                      label = "start-tools-end",
-                      timeout = roadblock_timeouts["default"],
-                      redis_password = roadblock_password,
-                      msgs_dir = roadblock_messages_dir,
-                      connection_watchdog = roadblock_connection_watchdog)
-    if rc != 0:
-        return rc
+        rc = do_roadblock(roadblock_id = roadblock_id,
+                          follower_id = endpoint_label,
+                          label = "collect-sysinfo-begin",
+                          timeout = roadblock_timeouts["collect-sysinfo"],
+                          redis_password = roadblock_password,
+                          msgs_dir = roadblock_messages_dir,
+                          connection_watchdog = roadblock_connection_watchdog)
+        if rc != 0:
+            return rc
+        callback = "collect-sysinfo"
+        engine_init_msgs = None
+        if callback in callbacks and callbacks[callback] is not None:
+            logger.info("Calling endpoint specified callback for '%s'" % (callback))
+            engine_init_msgs = callbacks[callback]()
+        else:
+            logger.info("Calling endpoint did not specify a callback for '%s'" % (callback))
+        rc = do_roadblock(roadblock_id = roadblock_id,
+                          follower_id = endpoint_label,
+                          label = "collect-sysinfo-end",
+                          timeout = roadblock_timeouts["collect-sysinfo"],
+                          redis_password = roadblock_password,
+                          msgs_dir = roadblock_messages_dir,
+                          connection_watchdog = roadblock_connection_watchdog)
+        if rc != 0:
+            return rc
 
-    rc = process_bench_roadblocks(callbacks = callbacks,
-                                  roadblock_id = roadblock_id,
-                                  endpoint_label = endpoint_label,
-                                  roadblock_password = roadblock_password,
-                                  max_sample_failures = max_sample_failures,
-                                  roadblock_messages_dir = roadblock_messages_dir,
-                                  roadblock_timeouts = roadblock_timeouts,
-                                  engine_commands_dir = engine_commands_dir,
-                                  endpoint_dir = endpoint_dir,
-                                  roadblock_connection_watchdog = roadblock_connection_watchdog)
-    if rc != 0:
-        return rc
+        rc = do_roadblock(roadblock_id = roadblock_id,
+                          follower_id = endpoint_label,
+                          label = "start-tools-begin",
+                          timeout = roadblock_timeouts["default"],
+                          redis_password = roadblock_password,
+                          msgs_dir = roadblock_messages_dir,
+                          connection_watchdog = roadblock_connection_watchdog)
+        if rc != 0:
+            return rc
+        rc = do_roadblock(roadblock_id = roadblock_id,
+                          follower_id = endpoint_label,
+                          label = "start-tools-end",
+                          timeout = roadblock_timeouts["default"],
+                          redis_password = roadblock_password,
+                          msgs_dir = roadblock_messages_dir,
+                          connection_watchdog = roadblock_connection_watchdog)
+        if rc != 0:
+            return rc
+
+        rc = process_bench_roadblocks(callbacks = callbacks,
+                                      roadblock_id = roadblock_id,
+                                      endpoint_label = endpoint_label,
+                                      roadblock_password = roadblock_password,
+                                      max_sample_failures = max_sample_failures,
+                                      roadblock_messages_dir = roadblock_messages_dir,
+                                      roadblock_timeouts = roadblock_timeouts,
+                                      engine_commands_dir = engine_commands_dir,
+                                      endpoint_dir = endpoint_dir,
+                                      roadblock_connection_watchdog = roadblock_connection_watchdog)
+        if rc != 0:
+            return rc
+
+        roadblocks_completed = True
+    finally:
+        if not roadblocks_completed:
+            callback = "rescue-engine-logs"
+            if callbacks is not None and callback in callbacks and callbacks[callback] is not None:
+                logger.error("Rescuing engine logs due to early exit from process_roadblocks")
+                try:
+                    callbacks[callback]()
+                except Exception as err:
+                    logger.error("Engine log rescue failed during early-exit handling: %s", err)
 
     do_roadblock(roadblock_id = roadblock_id,
                  follower_id = endpoint_label,

--- a/endpoints/kube/kube.py
+++ b/endpoints/kube/kube.py
@@ -2134,6 +2134,63 @@ def create_tools_pods(abort_event):
             
     return 0
 
+def rescue_engine_logs():
+    """
+    Rescue engine container logs from all pods during error state without deleting the namespace or cleaning up the environment
+
+    Args:
+        None
+
+    Globals:
+        args (namespace): the script's CLI parameters
+        logger: a logger instance
+        settings (dict): the one data structure to rule then all
+
+    Returns:
+        0
+    """
+    logger.warning("Rescuing engine logs")
+
+    endpoint = settings["run-file"]["endpoints"][args.endpoint_index]
+
+    if "pods" not in settings["engines"]["endpoint"] or not settings["engines"]["endpoint"]["pods"]:
+        logger.warning("No pods to rescue engine logs from")
+        return 0
+
+    try:
+        with endpoints.remote_connection(settings["run-file"]["endpoints"][args.endpoint_index]["host"],
+                                         settings["run-file"]["endpoints"][args.endpoint_index]["user"]) as con:
+            processed_log_pods = set()
+            pods = list(settings["engines"]["endpoint"]["pods"].keys())
+            pods.sort()
+            for pod in pods:
+                pod_name = settings["engines"]["endpoint"]["pods"][pod]["name"]
+                if pod_name in processed_log_pods:
+                    continue
+                processed_log_pods.add(pod_name)
+                node_name = settings["engines"]["endpoint"]["pods"][pod]["node"]
+                logger.warning("Rescuing logs from pod '%s' on node '%s'" % (pod_name, node_name))
+                for engine in settings["engines"]["endpoint"]["pods"][pod]["containers"]:
+                    logger.warning("Rescuing log for engine '%s'" % (engine))
+                    k8s_pod_name = settings["engines"]["endpoint"]["pods"][pod].get("k8s-pod-name", "%s-%s" % (endpoint_default_settings["prefix"]["pod"], pod_name))
+                    cmd = "%s logs %s --namespace %s --container %s" % (settings["misc"]["k8s-bin"],
+                                                                         k8s_pod_name,
+                                                                         endpoint["namespace"]["name"],
+                                                                         engine)
+                    result = endpoints.run_remote(con, cmd, debug = settings["misc"]["debug-output"], env = settings["misc"]["remote-env"])
+                    if result.exited == 0:
+                        log_file = "%s/%s.txt.xz" % (settings["dirs"]["local"]["engine-logs"], engine)
+                        with lzma.open(log_file, "wt", encoding="utf-8") as lfh:
+                            lfh.write(result.stdout)
+                        logger.warning("Wrote rescued log for engine '%s' in pod '%s' to '%s'" % (engine, pod, log_file))
+                    else:
+                        logger.error("Failed to rescue log for engine '%s' in pod '%s'" % (engine, pod))
+                        endpoints.log_result(result)
+    except Exception as err:
+        logger.error("Failed to rescue engine logs: %s" % (err))
+
+    return 0
+
 def kube_cleanup():
     """
     Attempt to cleanup the K8S namespace by collecting logs from the pods and then deleting everything
@@ -3348,7 +3405,8 @@ def main():
                 "collect-sysinfo": collect_sysinfo,
                 "test-start": test_start,
                 "test-stop": test_stop,
-                "remote-cleanup": kube_cleanup
+                "remote-cleanup": kube_cleanup,
+                "rescue-engine-logs": rescue_engine_logs
             }
             if early_abort and not "new-followers" in settings["engines"]:
                 # in the case of an early abort the new-followers list may not

--- a/endpoints/kube/kube.py
+++ b/endpoints/kube/kube.py
@@ -2212,64 +2212,67 @@ def kube_cleanup():
 
     cleanup_error = "An error has been encountered during cleanup -> the namespace ('%s') will be left untouched for inspection" % (endpoint["namespace"]["name"])
 
-    with endpoints.remote_connection(settings["run-file"]["endpoints"][args.endpoint_index]["host"],
-                                     settings["run-file"]["endpoints"][args.endpoint_index]["user"]) as con:
-        errors = False
+    try:
+        with endpoints.remote_connection(settings["run-file"]["endpoints"][args.endpoint_index]["host"],
+                                         settings["run-file"]["endpoints"][args.endpoint_index]["user"]) as con:
+            errors = False
 
-        logger.info("Current K8S namespace '%s' status" % (endpoint["namespace"]["name"]))
-        cmd = "%s get all --namespace %s --output wide" % (settings["misc"]["k8s-bin"], endpoint["namespace"]["name"])
-        result = endpoints.run_remote(con, cmd, debug = settings["misc"]["debug-output"], env = settings["misc"]["remote-env"])
-        endpoints.log_result(result)
-        if result.exited != 0:
-            logger.error(cleanup_error)
-            errors = True
-
-        logger.info("Collecting engine logs")
-        processed_log_pods = set()
-        pods = list(settings["engines"]["endpoint"]["pods"].keys())
-        pods.sort()
-        for pod in pods:
-            pod_name = settings["engines"]["endpoint"]["pods"][pod]["name"]
-            if pod_name in processed_log_pods:
-                continue
-            processed_log_pods.add(pod_name)
-            node_name = settings["engines"]["endpoint"]["pods"][pod]["node"]
-            logger.info("Processing pod '%s' on node '%s'" % (pod_name, node_name))
-            for engine in settings["engines"]["endpoint"]["pods"][pod]["containers"]:
-                logger.info("Collecting log for engine '%s'" % (engine))
-                k8s_pod_name = settings["engines"]["endpoint"]["pods"][pod].get("k8s-pod-name", "%s-%s" % (endpoint_default_settings["prefix"]["pod"], pod_name))
-                cmd = "%s logs %s --namespace %s --container %s" % (settings["misc"]["k8s-bin"],
-                                                                     k8s_pod_name,
-                                                                     endpoint["namespace"]["name"],
-                                                                     engine)
-                result = endpoints.run_remote(con, cmd, debug = settings["misc"]["debug-output"], env = settings["misc"]["remote-env"])
-                if result.exited == 0:
-                    log_file = "%s/%s.txt.xz" % (settings["dirs"]["local"]["engine-logs"], engine)
-                    with lzma.open(log_file, "wt", encoding="utf-8") as lfh:
-                        lfh.write(result.stdout)
-                    logger.info("Wrote log for engine '%s' in pod '%s' to '%s'" % (engine, pod, log_file))
-                else:
-                    logger.error("Failed to collect log for engine '%s' in pod '%s'" % (engine, pod))
-                    endpoints.log_result(result)
-                    if not errors:
-                        logger.error(cleanup_error)
-                        errors = True
-
-        if not errors:
-            if clean_k8s_namespace(con):
+            logger.info("Current K8S namespace '%s' status" % (endpoint["namespace"]["name"]))
+            cmd = "%s get all --namespace %s --output wide" % (settings["misc"]["k8s-bin"], endpoint["namespace"]["name"])
+            result = endpoints.run_remote(con, cmd, debug = settings["misc"]["debug-output"], env = settings["misc"]["remote-env"])
+            endpoints.log_result(result)
+            if result.exited != 0:
                 logger.error(cleanup_error)
                 errors = True
-            else:
-                logger.info("Deleting namepsace: %s" % (endpoint["namespace"]["name"]))
-                cmd = "%s delete namespace %s" % (settings["misc"]["k8s-bin"], endpoint["namespace"]["name"])
-                result = endpoints.run_remote(con, cmd, debug = settings["misc"]["debug-output"], env = settings["misc"]["remote-env"])
-                endpoints.log_result(result)
-                if result.exited != 0:
-                    logger.error("Failed to delete namespace: %s" % (endpoint["namespace"]["name"]))
+
+            logger.info("Collecting engine logs")
+            processed_log_pods = set()
+            pods = list(settings["engines"]["endpoint"]["pods"].keys())
+            pods.sort()
+            for pod in pods:
+                pod_name = settings["engines"]["endpoint"]["pods"][pod]["name"]
+                if pod_name in processed_log_pods:
+                    continue
+                processed_log_pods.add(pod_name)
+                node_name = settings["engines"]["endpoint"]["pods"][pod]["node"]
+                logger.info("Processing pod '%s' on node '%s'" % (pod_name, node_name))
+                for engine in settings["engines"]["endpoint"]["pods"][pod]["containers"]:
+                    logger.info("Collecting log for engine '%s'" % (engine))
+                    k8s_pod_name = settings["engines"]["endpoint"]["pods"][pod].get("k8s-pod-name", "%s-%s" % (endpoint_default_settings["prefix"]["pod"], pod_name))
+                    cmd = "%s logs %s --namespace %s --container %s" % (settings["misc"]["k8s-bin"],
+                                                                         k8s_pod_name,
+                                                                         endpoint["namespace"]["name"],
+                                                                         engine)
+                    result = endpoints.run_remote(con, cmd, debug = settings["misc"]["debug-output"], env = settings["misc"]["remote-env"])
+                    if result.exited == 0:
+                        log_file = "%s/%s.txt.xz" % (settings["dirs"]["local"]["engine-logs"], engine)
+                        with lzma.open(log_file, "wt", encoding="utf-8") as lfh:
+                            lfh.write(result.stdout)
+                        logger.info("Wrote log for engine '%s' in pod '%s' to '%s'" % (engine, pod, log_file))
+                    else:
+                        logger.error("Failed to collect log for engine '%s' in pod '%s'" % (engine, pod))
+                        endpoints.log_result(result)
+                        if not errors:
+                            logger.error(cleanup_error)
+                            errors = True
+
+            if not errors:
+                if clean_k8s_namespace(con):
                     logger.error(cleanup_error)
                     errors = True
-        else:
-            logger.warning("Skipping namespace cleanup due to prior errors")
+                else:
+                    logger.info("Deleting namepsace: %s" % (endpoint["namespace"]["name"]))
+                    cmd = "%s delete namespace %s" % (settings["misc"]["k8s-bin"], endpoint["namespace"]["name"])
+                    result = endpoints.run_remote(con, cmd, debug = settings["misc"]["debug-output"], env = settings["misc"]["remote-env"])
+                    endpoints.log_result(result)
+                    if result.exited != 0:
+                        logger.error("Failed to delete namespace: %s" % (endpoint["namespace"]["name"]))
+                        logger.error(cleanup_error)
+                        errors = True
+            else:
+                logger.warning("Skipping namespace cleanup due to prior errors")
+    except Exception as err:
+        logger.error("Failed to cleanup K8S namespace: %s" % (err))
 
     return 0
 

--- a/endpoints/kube/kube.py
+++ b/endpoints/kube/kube.py
@@ -2158,8 +2158,7 @@ def rescue_engine_logs():
         return 0
 
     try:
-        with endpoints.remote_connection(settings["run-file"]["endpoints"][args.endpoint_index]["host"],
-                                         settings["run-file"]["endpoints"][args.endpoint_index]["user"]) as con:
+        with endpoints.remote_connection(endpoint["host"], endpoint["user"]) as con:
             processed_log_pods = set()
             pods = list(settings["engines"]["endpoint"]["pods"].keys())
             pods.sort()

--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -511,6 +511,7 @@ def image_pull_worker_thread(thread_id, work_queue, threads_rcs):
 
         if remote is None:
             thread_logger("Received a null job", log_level = "warning")
+            work_queue.task_done()
             continue
 
         job_count += 1
@@ -759,6 +760,7 @@ def remote_mkdirs_worker_thread(thread_id, work_queue, threads_rcs):
 
         if remote is None:
             thread_logger("Received a null job", log_level = "warning")
+            work_queue.task_done()
             continue
 
         job_count += 1
@@ -1231,6 +1233,7 @@ def launch_engines_worker_thread(thread_id, work_queue, threads_rcs):
 
         if remote_idx is None:
             thread_logger("Received a null job", log_level = "warning")
+            work_queue.task_done()
             continue
 
         job_count += 1
@@ -2108,6 +2111,7 @@ def shutdown_engines_worker_thread(thread_id, work_queue, threads_rcs):
 
         if remote_idx is None:
             thread_logger("Received a null job", log_level = "warning")
+            work_queue.task_done()
             continue
 
         job_count += 1
@@ -2228,6 +2232,7 @@ def image_mgmt_worker_thread(thread_id, work_queue, threads_rcs):
 
         if remote is None:
             thread_logger("Received a null job", log_level = "warning")
+            work_queue.task_done()
             continue
 
         job_count += 1
@@ -2304,6 +2309,7 @@ def rescue_engine_logs_worker_thread(thread_id, work_queue, threads_rcs):
 
         if remote_idx is None:
             thread_logger("Received a null job", log_level = "warning")
+            work_queue.task_done()
             continue
 
         job_count += 1
@@ -2418,6 +2424,7 @@ def collect_sysinfo_worker_thread(thread_id, work_queue, threads_rcs):
 
         if remote is None:
             thread_logger("Received a null job", log_level = "warning")
+            work_queue.task_done()
             continue
 
         job_count += 1

--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -2118,48 +2118,51 @@ def shutdown_engines_worker_thread(thread_id, work_queue, threads_rcs):
         thread_logger("Processing remote '%s' at index %d" % (remote["config"]["host"], remote_idx), remote_name = remote_name)
         thread_logger("Remote user is %s" % (remote["config"]["settings"]["remote-user"]), remote_name = remote_name)
 
-        with endpoints.remote_connection(remote["config"]["host"], remote["config"]["settings"]["remote-user"]) as con:
-            result = endpoints.run_remote(con, "mount")
-            thread_logger("All mounts on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+        try:
+            with endpoints.remote_connection(remote["config"]["host"], remote["config"]["settings"]["remote-user"]) as con:
+                result = endpoints.run_remote(con, "mount")
+                thread_logger("All mounts on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
-            result = endpoints.run_remote(con, "podman ps --all")
-            thread_logger("All podman pods on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+                result = endpoints.run_remote(con, "podman ps --all")
+                thread_logger("All podman pods on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
-            result = endpoints.run_remote(con, "podman mount")
-            thread_logger("All podman container mounts on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+                result = endpoints.run_remote(con, "podman mount")
+                thread_logger("All podman container mounts on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
-            for engine in remote["engines"]:
-                for engine_id in engine["ids"]:
-                    engine_name = "%s-%s" % (engine["role"], str(engine_id))
-                    container_name = "%s_%s" % (settings["misc"]["run-id"], engine_name)
-                    thread_logger("Processing engine '%s'" % (engine_name), remote_name = remote_name, engine_name = engine_name)
-                    thread_logger("Container name is '%s'" % (container_name), remote_name = remote_name, engine_name = engine_name)
+                for engine in remote["engines"]:
+                    for engine_id in engine["ids"]:
+                        engine_name = "%s-%s" % (engine["role"], str(engine_id))
+                        container_name = "%s_%s" % (settings["misc"]["run-id"], engine_name)
+                        thread_logger("Processing engine '%s'" % (engine_name), remote_name = remote_name, engine_name = engine_name)
+                        thread_logger("Container name is '%s'" % (container_name), remote_name = remote_name, engine_name = engine_name)
 
-                    osruntime = None
-                    if engine["role"] == "profiler":
-                        osruntime = "podman"
-                    else:
-                        osruntime = remote["config"]["settings"]["osruntime"]
-                    thread_logger("osruntime is '%s'" % (osruntime), remote_name = remote_name, engine_name = engine_name)
+                        osruntime = None
+                        if engine["role"] == "profiler":
+                            osruntime = "podman"
+                        else:
+                            osruntime = remote["config"]["settings"]["osruntime"]
+                        thread_logger("osruntime is '%s'" % (osruntime), remote_name = remote_name, engine_name = engine_name)
 
-                    match osruntime:
-                        case "podman":
-                            success = collect_podman_log(thread_name, remote_name, engine_name, container_name, con)
-                            if success:
-                                destroy_podman(thread_name, remote_name, engine_name, container_name, con)
-                        case "chroot":
-                            success = collect_chroot_log(thread_name, remote_name, engine_name, container_name, con)
-                            if success:
-                                destroy_chroot(thread_name, remote_name, engine_name, container_name, con, remote["chroots"][engine_name])
+                        match osruntime:
+                            case "podman":
+                                success = collect_podman_log(thread_name, remote_name, engine_name, container_name, con)
+                                if success:
+                                    destroy_podman(thread_name, remote_name, engine_name, container_name, con)
+                            case "chroot":
+                                success = collect_chroot_log(thread_name, remote_name, engine_name, container_name, con)
+                                if success:
+                                    destroy_chroot(thread_name, remote_name, engine_name, container_name, con, remote["chroots"][engine_name])
 
-            result = endpoints.run_remote(con, "mount")
-            thread_logger("All mounts on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+                result = endpoints.run_remote(con, "mount")
+                thread_logger("All mounts on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
-            result = endpoints.run_remote(con, "podman ps --all")
-            thread_logger("All podman pods on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+                result = endpoints.run_remote(con, "podman ps --all")
+                thread_logger("All podman pods on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
 
-            result = endpoints.run_remote(con, "podman mount")
-            thread_logger("All podman container mounts on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+                result = endpoints.run_remote(con, "podman mount")
+                thread_logger("All podman container mounts on this remote host:\nstdout:\n%s\nstderr:\n%s" % (result.stdout, result.stderr), remote_name = remote_name)
+        except Exception as err:
+            thread_logger("Failed to shutdown engines on remote '%s': %s" % (remote["config"]["host"], err), log_level = "error", remote_name = remote_name)
 
         thread_logger("Notifying work queue that job processing is complete", remote_name = remote_name)
         work_queue.task_done()

--- a/endpoints/remotehosts/remotehosts.py
+++ b/endpoints/remotehosts/remotehosts.py
@@ -1576,7 +1576,7 @@ def collect_podman_log(thread_name, remote_name, engine_name, container_name, co
     else:
         return True
 
-def collect_chroot_log(thread_name, remote_name, engine_name, container_name, connection):
+def collect_chroot_log(thread_name, remote_name, engine_name, container_name, connection, remove = True):
     """
     Use an existing connection to collect the chroot logs for a specific engine
 
@@ -1586,6 +1586,7 @@ def collect_chroot_log(thread_name, remote_name, engine_name, container_name, co
         engine_name (str): The specific engine that is being created
         container_name (str): The name to use for the pod on the remote
         connection (Fabric): The Fabric connection to use to run commands on the remote
+        remove (bool): Whether to remove the remote log file after collection
 
     Globals:
         settings (dict): the one data structure to rule then all
@@ -1614,14 +1615,15 @@ def collect_chroot_log(thread_name, remote_name, engine_name, container_name, co
             log_file_fp.write(base64.b64decode(result.stdout))
         thread_logger("Wrote chroot log to %s" % (log_file), remote_name = remote_name, engine_name = engine_name)
 
-        result = endpoints.run_remote(connection, "rm --verbose " + remote_log_file)
-        thread_logger("Removal of engine log for '%s' gave return code %d:\nstdout:\n%stderr:\n%s" %
-                      (
-                          engine_name,
-                          result.exited,
-                          result.stdout,
-                          result.stderr
-                      ), log_level =  endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
+        if remove:
+            result = endpoints.run_remote(connection, "rm --verbose " + remote_log_file)
+            thread_logger("Removal of engine log for '%s' gave return code %d:\nstdout:\n%stderr:\n%s" %
+                          (
+                              engine_name,
+                              result.exited,
+                              result.stdout,
+                              result.stderr
+                          ), log_level =  endpoints.get_result_log_level(result), remote_name = remote_name, engine_name = engine_name)
         return True
 
 def remove_rickshaw_settings(connection, thread_name, remote_name, engine_name):
@@ -2267,6 +2269,101 @@ def image_mgmt():
 
     return 0
 
+def rescue_engine_logs_worker_thread(thread_id, work_queue, threads_rcs):
+    """
+    Worker thread to rescue engine logs from a remote during error state without destroying containers
+
+    Args:
+        thread_id (int): The specifc worker thread that this is
+        work_queue (Queue): The work queue to pull jobs to process from
+        threads_rcs (list): The list to record the threads return code in
+
+    Globals:
+        args (namespace): the script's CLI parameters
+        settings (dict): the one data structure to rule then all
+
+    Returns:
+        None
+    """
+    thread = threading.current_thread()
+    thread_name = thread.name
+    thread_logger("Starting rescue engine logs thread with thread ID %d and name = '%s'" % (thread_id, thread_name), log_level = "warning")
+    rc = 0
+    job_count = 0
+
+    while not work_queue.empty():
+        remote_idx = None
+        try:
+            remote_idx = work_queue.get(block = False)
+        except queue.Empty:
+            thread_logger("Received a work queue empty exception", log_level = "warning")
+            break
+
+        if remote_idx is None:
+            thread_logger("Received a null job", log_level = "warning")
+            continue
+
+        job_count += 1
+
+        remote = settings["run-file"]["endpoints"][args.endpoint_index]["remotes"][remote_idx]
+        remote_name = "%s-%s" % (remote["config"]["host"], remote_idx)
+
+        thread_logger("Rescuing engine logs from remote '%s' at index %d" % (remote["config"]["host"], remote_idx), log_level = "warning", remote_name = remote_name)
+
+        try:
+            with endpoints.remote_connection(remote["config"]["host"], remote["config"]["settings"]["remote-user"]) as con:
+                for engine in remote["engines"]:
+                    for engine_id in engine["ids"]:
+                        engine_name = "%s-%s" % (engine["role"], str(engine_id))
+                        container_name = "%s_%s" % (settings["misc"]["run-id"], engine_name)
+                        thread_logger("Rescuing log for engine '%s'" % (engine_name), log_level = "warning", remote_name = remote_name, engine_name = engine_name)
+
+                        osruntime = None
+                        if engine["role"] == "profiler":
+                            osruntime = "podman"
+                        else:
+                            osruntime = remote["config"]["settings"]["osruntime"]
+
+                        match osruntime:
+                            case "podman":
+                                collect_podman_log(thread_name, remote_name, engine_name, container_name, con)
+                            case "chroot":
+                                collect_chroot_log(thread_name, remote_name, engine_name, container_name, con, remove = False)
+        except Exception as err:
+            thread_logger("Failed to rescue engine logs from remote '%s': %s" % (remote["config"]["host"], err), log_level = "error", remote_name = remote_name)
+
+        thread_logger("Notifying work queue that job processing is complete", log_level = "warning", remote_name = remote_name)
+        work_queue.task_done()
+
+    threads_rcs[thread_id] = rc
+    thread_logger("Stopping rescue engine logs thread after processing %d job(s)" % (job_count), log_level = "warning")
+    return
+
+def rescue_engine_logs():
+    """
+    Rescue engine container logs from all remotes during error state without destroying containers or cleaning up the environment
+
+    Args:
+        None
+
+    Globals:
+        args (namespace): the script's CLI parameters
+        settings (dict): the one data structure to rule then all
+
+    Returns:
+        0
+    """
+    logger.warning("Creating threadpool to rescue engine logs")
+
+    collect_work = queue.Queue()
+    for remote_idx,remote in enumerate(settings["run-file"]["endpoints"][args.endpoint_index]["remotes"]):
+        collect_work.put(remote_idx)
+    worker_threads_count = len(settings["run-file"]["endpoints"][args.endpoint_index]["remotes"])
+
+    create_thread_pool("Rescue Engine Logs Worker Threads", "RELWT", collect_work, worker_threads_count, rescue_engine_logs_worker_thread)
+
+    return 0
+
 def remote_cleanup():
     """
     Cleanup the remotes after a test
@@ -2479,7 +2576,8 @@ def main():
         "collect-sysinfo": collect_sysinfo,
         "test-start": test_start,
         "test-stop": test_stop,
-        "remote-cleanup": remote_cleanup
+        "remote-cleanup": remote_cleanup,
+        "rescue-engine-logs": rescue_engine_logs
     }
     rc = endpoints.process_roadblocks(callbacks = remotehosts_callbacks,
                                       roadblock_id = args.roadblock_id,


### PR DESCRIPTION
## Summary

- When an engine fails during init-phase roadblocks (endpoint-deploy through start-tools), `process_roadblocks()` returns early and the `remote-cleanup` callback never fires — engine container logs are permanently lost. Add a `rescue-engine-logs` callback that fires via a `try/finally` guard on early exit, collecting engine logs without destroying containers or cleaning up the environment so the endpoint remains intact for debugging.
- `shutdown_engines_worker_thread` (remotehosts) and `kube_cleanup` (kube) can crash with an unhandled exception when `remote_connection()` fails after exhausting retries. In the worker thread case, this causes `work.join()` to hang indefinitely because `task_done()` is never called. Wrap remote operations in `try/except` so unreachable endpoints are logged as errors and execution continues gracefully.

## Design

- The `try/finally` in `process_roadblocks()` wraps only the roadblocks that have early returns (endpoint-deploy through process_bench_roadblocks), not the post-bench fire-and-forget roadblocks or the normal cleanup callback
- Rescue functions (`rescue_engine_logs`, `rescue_engine_logs_worker_thread` in remotehosts; `rescue_engine_logs` in kube) are separate from the normal cleanup path to allow independent evolution of failure-specific collection
- `collect_chroot_log()` gains a `remove` parameter so the rescue path preserves remote log files
- Rescue functions use WARNING log level for operational messages, ERROR at the entry point
- All rescue and cleanup functions are resilient to unreachable endpoints via `try/except` around remote connections

## Test plan

- [x] Success path: normal run completes with no rescue triggered
- [x] Failure path: injected `sys.exit(1)` after engine-init-begin — all 5 engine logs rescued (podman + chroot), containers left intact, no chroot log removal
- [x] Log levels: rescue messages at WARNING, entry point at ERROR, shared `collect_podman_log`/`collect_chroot_log` at their existing levels
- [x] Cleanup resilience: success path still works after adding `try/except` to `shutdown_engines_worker_thread` and `kube_cleanup`

Resolves: https://github.com/perftool-incubator/rickshaw/issues/853 (partial — improves error-path diagnostics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)