### PR TITLE
feat: support multi-stage workshop files for benchmarks and tools

### DIFF
--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -6,6 +6,7 @@
 # endpoints, sources container images, deploys engines via roadblock
 # synchronization, and organizes results.
 
+import glob
 import json
 import os
 import platform
@@ -696,24 +697,38 @@ class RunState:
             self.run["benchmark"] += f",{benchmark_name}"
             self.bench_configs[benchmark_name] = bench_config_ref
 
-            has_client_workshop = os.path.exists(os.path.join(this_bench_dir, "client-workshop.json"))
-            has_server_workshop = os.path.exists(os.path.join(this_bench_dir, "server-workshop.json"))
-            has_plain_workshop = os.path.exists(os.path.join(this_bench_dir, "workshop.json"))
+            client_workshops = sorted(glob.glob(os.path.join(this_bench_dir, "client-workshop*.json")))
+            server_workshops = sorted(glob.glob(os.path.join(this_bench_dir, "server-workshop*.json")))
+            plain_workshops = sorted(glob.glob(os.path.join(this_bench_dir, "workshop*.json")))
 
-            if has_client_workshop and has_server_workshop and has_plain_workshop:
-                logger.error("[ERROR] benchmark '%s' has workshop.json alongside client-workshop.json and server-workshop.json; remove workshop.json when using split workshop files", benchmark_name)
+            has_client_workshop = len(client_workshops) > 0
+            has_server_workshop = len(server_workshops) > 0
+            has_plain_workshop = len(plain_workshops) > 0
+
+            if has_plain_workshop and (has_client_workshop or has_server_workshop):
+                logger.error("[ERROR] benchmark '%s' has workshop*.json alongside client/server-workshop*.json; use one convention or the other", benchmark_name)
                 sys.exit(1)
 
             if has_client_workshop and not has_server_workshop:
-                logger.error("[ERROR] benchmark '%s' has client-workshop.json but is missing server-workshop.json; both are required for split workshop builds", benchmark_name)
+                logger.error("[ERROR] benchmark '%s' has client-workshop*.json but is missing server-workshop*.json; both roles are required for split workshop builds", benchmark_name)
                 sys.exit(1)
 
             if has_server_workshop and not has_client_workshop:
-                logger.error("[ERROR] benchmark '%s' has server-workshop.json but is missing client-workshop.json; both are required for split workshop builds", benchmark_name)
+                logger.error("[ERROR] benchmark '%s' has server-workshop*.json but is missing client-workshop*.json; both roles are required for split workshop builds", benchmark_name)
                 sys.exit(1)
 
+            for role, workshops in [("client", client_workshops), ("server", server_workshops), ("plain", plain_workshops)]:
+                prefix = "" if role == "plain" else f"{role}-"
+                unnumbered = os.path.join(this_bench_dir, f"{prefix}workshop.json")
+                numbered = [f for f in workshops if f != unnumbered]
+                if os.path.exists(unnumbered) and numbered:
+                    logger.error("[ERROR] benchmark '%s' has both %sworkshop.json and numbered %sworkshop-NN-*.json files; use one convention or the other",
+                                 benchmark_name, prefix, prefix)
+                    sys.exit(1)
+
             if has_client_workshop and has_server_workshop:
-                logger.info("Benchmark '%s' has split workshop files (client-workshop.json + server-workshop.json)", benchmark_name)
+                logger.info("Benchmark '%s' has split workshop files (%d client, %d server)",
+                            benchmark_name, len(client_workshops), len(server_workshops))
                 self.split_benchmarks[benchmark_name] = {
                     "client": f"{benchmark_name}::client",
                     "server": f"{benchmark_name}::server",

--- a/rickshaw-source-images-client.py
+++ b/rickshaw-source-images-client.py
@@ -119,14 +119,20 @@ def _remap_workshop_for_role(collected, role):
     remapped_files = []
     for entry in collected["files"]:
         fname = entry["filename"]
-        if fname.startswith(other_prefixes) or fname.startswith("workshop"):
-            continue
-        if fname.startswith(f"{role_prefix}workshop"):
-            remapped_files.append({
-                "filename": fname[len(role_prefix):],
-                "content_base64": entry["content_base64"],
-                "mode": entry["mode"],
-            })
+        is_workshop_json = fname.endswith(".json") and (
+            fname.startswith("workshop") or
+            fname.startswith("client-workshop") or
+            fname.startswith("server-workshop")
+        )
+        if is_workshop_json:
+            if fname.startswith(other_prefixes) or fname.startswith("workshop"):
+                continue
+            if fname.startswith(f"{role_prefix}workshop"):
+                remapped_files.append({
+                    "filename": fname[len(role_prefix):],
+                    "content_base64": entry["content_base64"],
+                    "mode": entry["mode"],
+                })
         else:
             remapped_files.append(entry)
 

--- a/rickshaw-source-images-client.py
+++ b/rickshaw-source-images-client.py
@@ -105,21 +105,25 @@ def _collect_directory(dir_path):
 def _remap_workshop_for_role(collected, role):
     """Remap a collected directory for a role-specific workshop build.
 
-    For split workshop benchmarks (client-workshop.json + server-workshop.json),
-    rename {role}-workshop.json to workshop.json and exclude the other role's
-    workshop file so the source-images-service sees a standard workshop.json.
+    For split workshop benchmarks, rename {role}-workshop*.json files to
+    workshop*.json (stripping the role prefix) and exclude the other role's
+    workshop files so the source-images-service sees standard workshop*.json.
+
+    Supports both single-file ({role}-workshop.json -> workshop.json) and
+    multi-stage ({role}-workshop-NN-name.json -> workshop-NN-name.json).
     """
-    role_filename = f"{role}-workshop.json"
+    role_prefix = f"{role}-"
     other_roles = {"client", "server"} - {role}
-    exclude_filenames = {f"{r}-workshop.json" for r in other_roles} | {"workshop.json"}
+    other_prefixes = tuple(f"{r}-workshop" for r in other_roles)
 
     remapped_files = []
     for entry in collected["files"]:
-        if entry["filename"] in exclude_filenames:
+        fname = entry["filename"]
+        if fname.startswith(other_prefixes) or fname.startswith("workshop"):
             continue
-        if entry["filename"] == role_filename:
+        if fname.startswith(f"{role_prefix}workshop"):
             remapped_files.append({
-                "filename": "workshop.json",
+                "filename": fname[len(role_prefix):],
                 "content_base64": entry["content_base64"],
                 "mode": entry["mode"],
             })

--- a/source-images-service/source_images_service/core/requirements_builder.py
+++ b/source-images-service/source_images_service/core/requirements_builder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -51,6 +52,11 @@ def _write_toolbox_req_json(config_dir: Path, toolbox_home: Path) -> Path:
     req_path = config_dir / "toolbox-req.json"
     req_path.write_text(json.dumps(req, indent=2) + "\n")
     return req_path
+
+
+def _natural_sort_key(path: Path):
+    """Sort key that orders numeric segments numerically, not lexicographically."""
+    return [int(s) if s.isdigit() else s.lower() for s in re.split(r'(\d+)', str(path))]
 
 
 @dataclass
@@ -119,7 +125,7 @@ def build_reqs(
 
     # 6. Benchmark workshop*.json (last — most likely to change)
     bench_dir = workspace_paths.bench_dirs / benchmark
-    workshop_files = sorted(bench_dir.glob("workshop*.json"))
+    workshop_files = sorted(bench_dir.glob("workshop*.json"), key=_natural_sort_key)
     for wf in workshop_files:
         suffix = wf.stem.replace("workshop", "").strip("-")
         description = f"{benchmark} {suffix}" if suffix else f"{benchmark} requirements"

--- a/source-images-service/source_images_service/core/requirements_builder.py
+++ b/source-images-service/source_images_service/core/requirements_builder.py
@@ -117,11 +117,14 @@ def build_reqs(
                 f"--requirement {utility_req}", [utility], f"{utility} requirements",
             ))
 
-    # 6. Benchmark workshop.json (last — most likely to change)
-    reqs.append(StageRequirement(
-        f"--requirement {workspace_paths.bench_dirs / benchmark / 'workshop.json'}",
-        [benchmark],
-        f"{benchmark} requirements",
-    ))
+    # 6. Benchmark workshop*.json (last — most likely to change)
+    bench_dir = workspace_paths.bench_dirs / benchmark
+    workshop_files = sorted(bench_dir.glob("workshop*.json"))
+    for wf in workshop_files:
+        suffix = wf.stem.replace("workshop", "").strip("-")
+        description = f"{benchmark} {suffix}" if suffix else f"{benchmark} requirements"
+        reqs.append(StageRequirement(
+            f"--requirement {wf}", [benchmark], description,
+        ))
 
     return reqs


### PR DESCRIPTION
## Summary

- Allow benchmarks and tools to split a workshop file into ordered sub-stages using numbered files (`workshop-NN-name.json` or `{role}-workshop-NN-name.json`), where each file becomes its own cached build stage
- Enables independent cache invalidation — changing one component (e.g., ptp-latency) no longer forces rebuilding unrelated components (e.g., TRex) in the same benchmark
- Fully backwards compatible — plain `workshop.json` / `client-workshop.json` / `server-workshop.json` continue to work unchanged

## Test plan

- [x] Run a benchmark with a single `workshop.json` (e.g., fio) — should work unchanged
- [x] Run trafficgen with split `client-workshop-01-trex.json` + `client-workshop-02-ptp-latency.json` — should produce two client stages
- [x] Change only `ptp-latency.c`, run again — only the 02-ptp-latency stage should rebuild; 01-trex should be a cache hit
- [x] Verify stage descriptions in SIS log output show descriptive labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)