### PR TITLE
feat: add v10dev support to rickshaw-gen-docs

### DIFF
--- a/rickshaw-gen-docs.py
+++ b/rickshaw-gen-docs.py
@@ -32,7 +32,7 @@ from rickshaw_lib.schema_fixup import rickshaw_run_schema_fixup
 
 logger = None
 
-SUPPORTED_CDM_VERS = ["v7dev", "v8dev", "v9dev"]
+SUPPORTED_CDM_VERS = ["v7dev", "v8dev", "v9dev", "v10dev"]
 
 
 def generate_uuid():
@@ -70,16 +70,12 @@ class CDMState:
     def get_index_base_name(self):
         if self.ver in ("v7dev", "v8dev"):
             return f"cdm{self.ver}-"
-        elif self.ver == "v9dev":
-            return "cdm-v9dev-"
-        return f"cdm{self.ver}-"
+        return f"cdm-{self.ver}-"
 
     def get_index_name(self, doctype, year, month):
         if self.ver in ("v7dev", "v8dev"):
             return doctype
-        elif self.ver == "v9dev":
-            return f"{doctype}@{year}.{month}"
-        return doctype
+        return f"{doctype}@{year}.{month}"
 
     def get_index_full_name(self, doctype, year, month):
         return self.get_index_base_name() + self.get_index_name(doctype, year, month)

--- a/rickshaw-gen-docs.py
+++ b/rickshaw-gen-docs.py
@@ -326,7 +326,7 @@ def main():
     rickshaw_project_dir = str(Path(__file__).resolve().parent)
     result_schema_file = os.path.join(rickshaw_project_dir, "schema", "rickshaw-run.json")
 
-    # Extract year/month from run dir name for CDMv9 index naming
+    # Extract year/month from run dir name for CDMv9+ index naming
     year = None
     month = None
     m = re.search(r'--(\d{4})-(\d{2})-\d{2}_', base_run_dir)


### PR DESCRIPTION
## Summary

- Add `v10dev` to `SUPPORTED_CDM_VERS` in `rickshaw-gen-docs.py`
- Generalize `get_index_base_name()` and `get_index_name()` so v10dev and future versions use the v9dev index naming format (`cdm-{ver}-{doctype}@{year}.{month}`) instead of falling through to the legacy `cdm{ver}-{doctype}` format

### Context

CDM PR#202 added v10dev with `default-aggregation` support. This rickshaw change enables `rickshaw-gen-docs.py` to generate NDJSON documents with v10dev index names when `--ver v10dev` is passed.

### Jira

PERFNFV-410 (under epic PERFNFV-409)

## Test plan

- [x] End-to-end: `crucible run` with v10dev indexing — documents generated with correct `cdm-v10dev-{doctype}@{year}.{month}` index names
- [x] Backward compatibility: v9dev runs still generate correct index names

🤖 Generated with [Claude Code](https://claude.com/claude-code)