### PR TITLE
feat: validate rickshaw.json against schemas at load time

### DIFF
--- a/rickshaw-run.py
+++ b/rickshaw-run.py
@@ -30,7 +30,7 @@ if RICKSHAW_HOME:
     sys.path.append(RICKSHAW_HOME)
 
 from toolbox.fileio import open_write_text_file
-from toolbox.json import load_json_file, save_json_file
+from toolbox.json import load_json_file, save_json_file, validate_schema
 from toolbox.jsonsettings import get_json_setting
 import logging
 from toolbox.logging import setup_logging
@@ -687,6 +687,11 @@ class RunState:
                 logger.error("Could not open the bench config file: %s", err)
                 sys.exit(1)
 
+            valid, err = validate_schema(bench_config_ref, self.bench_schema_file)
+            if not valid:
+                logger.error("Schema validation failed for %s: %s", bench_config_file, err)
+                sys.exit(1)
+
             benchmark_name = bench_config_ref.get("benchmark")
             if not benchmark_name:
                 logger.error("[ERROR] benchmark was not defined in %s", bench_config_file)
@@ -1272,6 +1277,10 @@ class RunState:
                 if tool_cfg is None:
                     logger.error("Could not open the tool config file: %s", this_tool_config)
                     sys.exit(1)
+                valid, err = validate_schema(tool_cfg, self.tool_schema_file)
+                if not valid:
+                    logger.error("Schema validation failed for %s: %s", this_tool_config, err)
+                    sys.exit(1)
                 if tool_cfg.get("tool") != tool_name:
                     logger.error("In tool config %s, 'tool' does not match '%s'", this_tool_config, tool_name)
                     sys.exit(1)
@@ -1291,6 +1300,10 @@ class RunState:
                 json_ref, err = load_json_file(this_utility_config)
                 if json_ref is None:
                     logger.error("Could not open the utility config file: %s", this_utility_config)
+                    sys.exit(1)
+                valid, err = validate_schema(json_ref, self.utility_schema_file)
+                if not valid:
+                    logger.error("Schema validation failed for %s: %s", this_utility_config, err)
                     sys.exit(1)
                 if json_ref.get("utility") != utility:
                     logger.error("In utility config %s, 'utility' does not match '%s'", this_utility_config, utility)

--- a/schema/tool.json
+++ b/schema/tool.json
@@ -185,7 +185,6 @@
   "required": [
     "rickshaw-tool",
     "tool",
-    "controller",
     "collector"
   ],
   "additionalProperties": false


### PR DESCRIPTION
## Summary
- Add `validate_schema()` calls for benchmark, tool, and utility `rickshaw.json` files at load time in `rickshaw-run.py`
- Make `controller` optional in the tool schema — tools like ftrace and kernel legitimately have no post-processing, and the code already handles this gracefully
- The schema files and validation infrastructure already existed but were never connected; this change closes that gap

Addresses [PERFNFV-454](https://redhat.atlassian.net/browse/PERFNFV-454) from the architecture review finding that rickshaw.json schemas were defined but never applied.

## Test plan
- [ ] Verified all 16 benchmarks and 13 tools pass schema validation (including ftrace and kernel which have no controller section)
- [ ] Verified invalid input is correctly rejected (typos like `fils-from-controller`, missing required fields like `start`)
- [ ] Integration test with `crucible run` using a known-good run file

🤖 Generated with [Claude Code](https://claude.com/claude-code)